### PR TITLE
Add 5 more printers

### DIFF
--- a/Kyocera_FS-1041GDI.ppd
+++ b/Kyocera_FS-1041GDI.ppd
@@ -1,0 +1,515 @@
+*PPD-Adobe: "4.3"
+*%=============================================================================
+*%
+*%  PPD file for Kyocera FS-1041 (European German)
+*%  Linux Version
+*%
+*% (C) 2012 KYOCERA Document Solutions Inc.
+*%
+*%  Permission is granted for redistribution of this file as long as this
+*%  copyright notice is intact and the contents of the file are not altered
+*%  in any way from their original form.
+*%
+*%  Permission is hereby granted, free of charge, to any person obtaining
+*%  a copy of this software and associated documentation files (the
+*%  "Software"), to deal in the Software without restriction, including
+*%  without limitation the rights to use, copy, modify, merge, publish,
+*%  distribute, sublicense, and/or sell copies of the Software, and to
+*%  permit persons to whom the Software is furnished to do so, subject to
+*%  the following conditions:
+*%
+*%  The above copyright notice and this permission notice shall be
+*%  included in all copies or substantial portions of the Software.
+*%
+*%  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+*%  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+*%  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+*%  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+*%  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+*%  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+*%  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*%
+*%  [this is the MIT open source license -- see www.opensource.org]
+*%
+*%=============================================================================
+
+*FileVersion: "1.1203"
+*FormatVersion: "4.3"
+*LanguageEncoding: ISOLatin1
+*LanguageVersion: German
+*Product: "(FS-1041)"
+*PSVersion: "(3011.103) 1"
+*Manufacturer: "Kyocera"
+*ModelName: "Kyocera FS-1041 KPSL"
+*ShortNickName: "Kyocera FS-1041 (KPSL)"
+*NickName: "Kyocera FS-1041 (KPSL)"
+*PCFileName: "KC1041EG.PPD"
+
+*1284DeviceID: "MDL:FS-1041;MFG:Kyocera"
+
+*cupsVersion: 1.2
+*cupsManualCopies: False
+*cupsModelNumber: 0
+*cupsSNMPSupplies: False
+
+*cupsFilter: "application/vnd.cups-raster 0 /usr/lib/cups/filter/rastertokpsl"
+
+*% Basic Device Capabilities
+*LandscapeOrientation: Plus90
+*AccurateScreensSupport: True
+*LanguageLevel: "3"
+*ColorDevice: False
+*ContoneOnly: False
+*DefaultColorSpace: Gray
+*TTRasterizer: Type42
+*?TTRasterizer: "
+  save
+  42 /FontType resourcestatus
+  { pop pop (Type42) }{ (None) } ifelse
+  = flush restore"
+*End
+
+*Throughput: "20"
+
+*% System Management
+*SuggestedJobTimeout: "0"
+*SuggestedManualFeedTimeout: "0"
+*SuggestedWaitTimeout: "120"
+*PrintPSErrors: True
+
+*Password: "0"
+
+*ExitServer: "
+  count 0 eq {true}
+  {dup statusdict /checkpassword get exec not} ifelse
+  {(WARNING : Cannot perform the exitserver command.) =
+    (Password supplied is not valid.) =
+    (Please contact the author of this software.) = flush quit} if
+  serverdict /exitserver get exec"
+*End
+
+*Reset: "
+  count 0 eq { true }
+  {dup statusdict /checkpassword get exec not} ifelse
+  {(WARNING : Cannot perform the exitserver command.) =
+    (Password supplied is not valid.) =
+    (Please contact the author of this software.) = flush quit} if
+  serverdict /exitserver get exec
+  systemdict /quit get exec
+  (WARNING : Printer Reset Failed.) = flush"
+*End
+
+*% Protocols
+*Protocols: TBCP
+
+*1284Modes Parallel: Compat Nibble ECP
+
+*% Virtual Memory
+*FreeVM: "32000000"
+
+*% Constraints
+*UIConstraints: *MediaType Labels *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Labels
+*UIConstraints: *MediaType Vellum *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Vellum
+*UIConstraints: *MediaType Envelope *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Envelope
+*UIConstraints: *MediaType Cardstock *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Cardstock
+
+*OpenGroup: GraphicsOptions/Grafiken
+
+*% Resolution 
+*OpenUI *Resolution/Aufl<F6>sung: PickOne
+*OrderDependency: 10 AnySetup *Resolution
+*DefaultResolution: 600dpi
+*Resolution 600dpi/600 dpi: "<< /HWResolution [600 600] /PreRenderingEnhance false >> setpagedevice"
+*CloseUI: *Resolution
+
+*% Color Model
+*OpenUI *ColorModel/Farbmodus: PickOne
+*OrderDependency: 10 AnySetup *ColorModel
+*DefaultColorModel: Gray
+*ColorModel Gray/Schwarz/Wei<DF>: "<< /ProcessColorModel /DeviceGray /cupsColorOrder 0/cupsColorSpace 3/cupsBitsPerColor 8/cupsCompression 1 >> setpagedevice"
+*CloseUI: *ColorModel
+
+*CloseGroup: GraphicsOptions/Grafiken
+
+*% Halftone Information 
+*DefaultHalftoneType: 1
+*ScreenFreq: "37.5"
+*ScreenAngle: "45.0"
+*ResScreenFreq 600dpi: "37.5"
+*ResScreenAngle 600dpi: "45.0"
+
+*DefaultScreenProc: Ellipse
+*ScreenProc Dot: "
+  {abs exch abs 2 copy add 1 gt
+  {1 sub dup mul exch 1 sub dup mul add 1 sub}
+  {dup mul exch dup mul add 1 exch sub} ifelse}"
+*End
+*ScreenProc Line: "{pop}"
+*ScreenProc Ellipse: "{dup 5 mul 8 div mul exch dup mul exch add sqrt 1 exch sub}"
+*DefaultTransfer: Null
+*Transfer Null: "{}"
+*Transfer Null.Inverse: "{1 exch sub}"
+
+*% Paper Handling 
+*% Page Size Definitions
+*OpenUI *PageSize: PickOne
+*OrderDependency: 40 AnySetup *PageSize
+*DefaultPageSize: A4
+*PageSize A4/A4: "<< /Policies << /PageSize 7 >> /PageSize [595 842] /ImagingBBox null >> setpagedevice"
+*PageSize A5/A5: "<< /Policies << /PageSize 7 >> /PageSize [421 595] /ImagingBBox null >> setpagedevice"
+*PageSize A6/A6: "<< /Policies << /PageSize 7 >> /PageSize [297 421] /ImagingBBox null >> setpagedevice"
+*PageSize B5/B5 (JIS): "<< /Policies << /PageSize 7 >> /PageSize [516 729] /ImagingBBox null >> setpagedevice"
+*PageSize ISOB5/B5 (ISO): "<< /Policies << /PageSize 7 >> /PageSize [499 708] /ImagingBBox null >> setpagedevice"
+*PageSize OficioII/Oficio II: "<< /Policies << /PageSize 7 >> /PageSize [612 936] /ImagingBBox null >> setpagedevice"
+*PageSize Folio/Folio (210 x 330mm): "<< /Policies << /PageSize 7 >> /PageSize [595 935] /ImagingBBox null >> setpagedevice"
+*PageSize Statement/Statement: "<< /Policies << /PageSize 7 >> /PageSize [396 612] /ImagingBBox null >> setpagedevice"
+*PageSize P16K/16K: "<< /Policies << /PageSize 7 >> /PageSize [558 774] /ImagingBBox null >> setpagedevice"
+*PageSize OficioMX/216 x 340 mm: "<< /Policies << /PageSize 7 >> /PageSize [612 964] /ImagingBBox null >> setpagedevice"
+*PageSize Letter/US-Letter: "<< /Policies << /PageSize 7 >> /PageSize [612 792] /ImagingBBox null >> setpagedevice"
+*PageSize Legal/US-Legal: "<< /Policies << /PageSize 7 >> /PageSize [612 1008] /ImagingBBox null >> setpagedevice"
+*PageSize Executive/US-Executive: "<< /Policies << /PageSize 7 >> /PageSize [522 756] /ImagingBBox null >> setpagedevice"
+*PageSize EnvPersonal/Umschlag #6: "<< /Policies << /PageSize 7 >> /PageSize [261 468] /ImagingBBox null >> setpagedevice"
+*PageSize Env9/Umschlag #9: "<< /Policies << /PageSize 7 >> /PageSize [279 639] /ImagingBBox null >> setpagedevice"
+*PageSize Env10/Umschlag #10: "<< /Policies << /PageSize 7 >> /PageSize [297 684] /ImagingBBox null >> setpagedevice"
+*PageSize EnvMonarch/Umschlag US-Monarch: "<< /Policies << /PageSize 7 >> /PageSize [279 540] /ImagingBBox null >> setpagedevice"
+*PageSize EnvDL/Umschlag DL: "<< /Policies << /PageSize 7 >> /PageSize [312 624] /ImagingBBox null >> setpagedevice"
+*PageSize EnvC5/Umschlag C5: "<< /Policies << /PageSize 7 >> /PageSize [459 649] /ImagingBBox null >> setpagedevice"
+*CloseUI: *PageSize
+
+*% Page Region Definitions for Frame Buffer
+*OpenUI *PageRegion: PickOne
+*OrderDependency: 40 AnySetup *PageRegion
+*DefaultPageRegion: A4
+*PageRegion A4/A4: "<< /Policies << /PageSize 7 >> /PageSize [595 842] /ImagingBBox null >> setpagedevice"
+*PageRegion A5/A5: "<< /Policies << /PageSize 7 >> /PageSize [421 595] /ImagingBBox null >> setpagedevice"
+*PageRegion A6/A6: "<< /Policies << /PageSize 7 >> /PageSize [297 421] /ImagingBBox null >> setpagedevice"
+*PageRegion B5/B5 (JIS): "<< /Policies << /PageSize 7 >> /PageSize [516 729] /ImagingBBox null >> setpagedevice"
+*PageRegion ISOB5/B5 (ISO): "<< /Policies << /PageSize 7 >> /PageSize [499 708] /ImagingBBox null >> setpagedevice"
+*PageRegion Letter/US-Letter: "<< /Policies << /PageSize 7 >> /PageSize [612 792] /ImagingBBox null >> setpagedevice"
+*PageRegion Legal/US-Legal: "<< /Policies << /PageSize 7 >> /PageSize [612 1008] /ImagingBBox null >> setpagedevice"
+*PageRegion Executive/US-Executive: "<< /Policies << /PageSize 7 >> /PageSize [522 756] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvPersonal/Umschlag #6: "<< /Policies << /PageSize 7 >> /PageSize [261 468] /ImagingBBox null >> setpagedevice"
+*PageRegion Env9/Umschlag #9: "<< /Policies << /PageSize 7 >> /PageSize [279 639] /ImagingBBox null >> setpagedevice"
+*PageRegion Env10/Umschlag #10: "<< /Policies << /PageSize 7 >> /PageSize [297 684] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvMonarch/Umschlag US-Monarch: "<< /Policies << /PageSize 7 >> /PageSize [279 540] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvDL/Umschlag DL: "<< /Policies << /PageSize 7 >> /PageSize [312 624] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvC5/Umschlag C5: "<< /Policies << /PageSize 7 >> /PageSize [459 649] /ImagingBBox null >> setpagedevice"
+*PageRegion OficioII/Oficio II: "<< /Policies << /PageSize 7 >> /PageSize [612 936] /ImagingBBox null >> setpagedevice"
+*PageRegion Folio/Folio (210 x 330mm): "<< /Policies << /PageSize 7 >> /PageSize [595 935] /ImagingBBox null >> setpagedevice"
+*PageRegion Statement/Statement: "<< /Policies << /PageSize 7 >> /PageSize [396 612] /ImagingBBox null >> setpagedevice"
+*PageRegion P16K/16K: "<< /Policies << /PageSize 7 >> /PageSize [558 774] /ImagingBBox null >> setpagedevice"
+*PageRegion OficioMX/216 x 340 mm: "<< /Policies << /PageSize 7 >> /PageSize [612 964] /ImagingBBox null >> setpagedevice"
+*CloseUI: *PageRegion
+
+*% Imageable Area Definitions
+*DefaultImageableArea: A4
+*ImageableArea A4/A4: "12 10 583 832"
+*ImageableArea A5/A5: "12 10 409 585"
+*ImageableArea A6/A6: "12 10 285 411"
+*ImageableArea B5/B5 (JIS): "21 10 495 719"
+*ImageableArea ISOB5/B5 (ISO): "12 12 487 696"
+*ImageableArea OficioII/Oficio II: "12 12 600 924"
+*ImageableArea Folio/Folio (210 x 330mm): "12 12 583 923"
+*ImageableArea Statement/Statement: "12 12 384 600"
+*ImageableArea P16K/16K: "12 12 547 763"
+*ImageableArea OficioMX/216 x 340 mm: "12 12 600 952"
+*ImageableArea Letter/US-Letter: "12 08 600 776"
+*ImageableArea Legal/US-Legal: "12 08 600 1000"
+*ImageableArea Executive/US-Executive: "12 08 510 748"
+*ImageableArea EnvPersonal/Umschlag #6: "12 08 249 460"
+*ImageableArea Env9/Umschlag #9: "12 08 267 631"
+*ImageableArea Env10/Umschlag #10: "12 08 285 676"
+*ImageableArea EnvMonarch/Umschlag US-Monarch: "12 08 267 532"
+*ImageableArea EnvDL/Umschlag DL: "12 10 300 614"
+*ImageableArea EnvC5/Umschlag C5: "12 10 447 639"
+*% Physical Dimensions of Media
+*DefaultPaperDimension: A4
+*PaperDimension A4/A4: "595 842"
+*PaperDimension A5/A5: "421 595"
+*PaperDimension A6/A6: "297 421"
+*PaperDimension B5/B5 (JIS): "516 729"
+*PaperDimension ISOB5/B5 (ISO): "499 708"
+*PaperDimension OficioII/Oficio II: "612 936"
+*PaperDimension Folio/Folio (210 x 330mm): "595 935"
+*PaperDimension Statement/Statement: "396 612"
+*PaperDimension P16K/16K: "558 774"
+*PaperDimension OficioMX/216 x 340 mm: "612 964"
+*PaperDimension Letter/US-Letter: "612 792"
+*PaperDimension Legal/US-Legal: "612 1008"
+*PaperDimension Executive/US-Executive: "522 756"
+*PaperDimension EnvPersonal/Umschlag #6: "261 468"
+*PaperDimension Env9/Umschlag #9: "279 639"
+*PaperDimension Env10/Umschlag #10: "297 684"
+*PaperDimension EnvMonarch/Umschlag US-Monarch: "279 540"
+*PaperDimension EnvDL/Umschlag DL: "312 624"
+*PaperDimension EnvC5/Umschlag C5: "459 649"
+
+*% Custom Page Size Definitions
+*% Smallest = A6, Largest = LEGAL
+
+*VariablePaperSize: True
+*LeadingEdge Short: ""
+*DefaultLeadingEdge: Short
+*HWMargins: 12 12 12 12
+*MaxMediaWidth: "612"
+*MaxMediaHeight: "1008"
+*NonUIOrderDependency: 40 AnySetup *CustomPageSize
+*CustomPageSize True: "
+  pop pop pop
+  << /PageSize [ 5 -2 roll ] /ImagingBBox null
+     /DeferredMediaSelection true
+  >> setpagedevice"
+*End
+*ParamCustomPageSize Width: 1 points 278 612
+*ParamCustomPageSize Height: 2 points 420 1008
+*ParamCustomPageSize WidthOffset: 3 points 0 0
+*ParamCustomPageSize HeightOffset: 4 points 0 0
+*ParamCustomPageSize Orientation: 5 int 1 1
+
+*OpenGroup: SpeedOptions/Modus reduzierter Geschwindigkeit
+
+*% Engine Speed Definitions
+*OpenUI *EngineSpeed/Modus reduzierter Geschwindigkeit: PickOne
+*OrderDependency: 40 AnySetup *EngineSpeed
+*DefaultEngineSpeed: Off
+*EngineSpeed On/Ein: ""
+*EngineSpeed Off/Aus: ""
+*CloseUI: *EngineSpeed
+
+*CloseGroup: SpeedOptions/Modus reduzierter Geschwindigkeit
+
+*OpenGroup: CaBrightness/Helligkeit
+
+*% Adjustment Definitions
+*OpenUI *CaBrightness/Helligkeit: PickOne
+*OrderDependency: 11 AnySetup *CaBrightness
+*DefaultCaBrightness: 0
+*CaBrightness -100/-100: ""
+*CaBrightness -90/-90: ""
+*CaBrightness -80/-80: ""
+*CaBrightness -70/-70: ""
+*CaBrightness -60/-60: ""
+*CaBrightness -50/-50: ""
+*CaBrightness -40/-40: ""
+*CaBrightness -30/-30: ""
+*CaBrightness -20/-20: ""
+*CaBrightness -10/-10: ""
+*CaBrightness 0/0: ""
+*CaBrightness 10/10: ""
+*CaBrightness 20/20: ""
+*CaBrightness 30/30: ""
+*CaBrightness 40/40: ""
+*CaBrightness 50/50: ""
+*CaBrightness 60/60: ""
+*CaBrightness 70/70: ""
+*CaBrightness 80/80: ""
+*CaBrightness 90/90: ""
+*CaBrightness 100/100: ""
+*CloseUI: *CaBrightness
+
+*CloseGroup: CaBrightness/Helligkeit
+
+*OpenGroup: CaContrast/Kontrast
+
+*% Adjustment Definitions
+*OpenUI *CaContrast/Kontrast: PickOne
+*OrderDependency: 12 AnySetup *CaContrast
+*DefaultCaContrast: 0
+*CaContrast -100/-100: ""
+*CaContrast -90/-90: ""
+*CaContrast -80/-80: ""
+*CaContrast -70/-70: ""
+*CaContrast -60/-60: ""
+*CaContrast -50/-50: ""
+*CaContrast -40/-40: ""
+*CaContrast -30/-30: ""
+*CaContrast -20/-20: ""
+*CaContrast -10/-10: ""
+*CaContrast 0/0: ""
+*CaContrast 10/10: ""
+*CaContrast 20/20: ""
+*CaContrast 30/30: ""
+*CaContrast 40/40: ""
+*CaContrast 50/50: ""
+*CaContrast 60/60: ""
+*CaContrast 70/70: ""
+*CaContrast 80/80: ""
+*CaContrast 90/90: ""
+*CaContrast 100/100: ""
+*CloseUI: *CaContrast
+
+*CloseGroup: CaContrast/Kontrast
+
+*OpenGroup: MediaOptions/Medientyp
+
+*% MediaType Definitions
+*OpenUI *MediaType/Medientyp: PickOne
+*OrderDependency: 95 AnySetup *MediaType
+*DefaultMediaType: PrnDef
+*MediaType PrnDef/Automatische Medienauswahl: "<</cupsMediaType 0 >> setpagedevice"
+*MediaType Plain/Normalpapier: "<</ManualFeed false /MediaType (Plain)/cupsMediaType 1 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Labels/Etiketten: "<</ManualFeed false /MediaType (Labels)/cupsMediaType 4 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Letterhead/Briefkopf: "<</ManualFeed false /MediaType (Letterhead)/cupsMediaType 9 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Bond/Feinpapier: "<</ManualFeed false /MediaType (Bond)/cupsMediaType 5 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Color/Mehrfarbig: "<</ManualFeed false /MediaType (Color)/cupsMediaType 10 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Preprinted/Vorgedruckt: "<</ManualFeed false /MediaType (Preprinted)/cupsMediaType 3 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Prepunched/Vorgelocht: "<</ManualFeed false /MediaType (Prepunched)/cupsMediaType 11 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Recycled/Recycling-Papier: "<</ManualFeed false /MediaType (Recycled)/cupsMediaType 6 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Cardstock/Karteikarte: "<</ManualFeed false /MediaType (Card Stock)/cupsMediaType 13 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Vellum/Pergament: "<</ManualFeed false /MediaType (Vellum)/cupsMediaType 7 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Envelope/Umschlag: "<</ManualFeed false /MediaType (Envelope)/cupsMediaType 12 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Rough/Grobpapier: "<</ManualFeed false /MediaType (Rough)/cupsMediaType 8 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Thick/Dick: "<</ManualFeed false /MediaType (Thick)/cupsMediaType 16 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Highqlty/Hohe Qualit<E4>t: "<</ManualFeed false /MediaType (Fine)/cupsMediaType 17 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User1/Benutzerdefinierter Typ 1: "<</ManualFeed false /MediaType (Custom Type1)/cupsMediaType 21 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User2/Benutzerdefinierter Typ 2: "<</ManualFeed false /MediaType (Custom Type2)/cupsMediaType 22 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User3/Benutzerdefinierter Typ 3: "<</ManualFeed false /MediaType (Custom Type3)/cupsMediaType 23 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User4/Benutzerdefinierter Typ 4: "<</ManualFeed false /MediaType (Custom Type4)/cupsMediaType 24 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User5/Benutzerdefinierter Typ 5: "<</ManualFeed false /MediaType (Custom Type5)/cupsMediaType 25 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User6/Benutzerdefinierter Typ 6: "<</ManualFeed false /MediaType (Custom Type6)/cupsMediaType 26 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User7/Benutzerdefinierter Typ 7: "<</ManualFeed false /MediaType (Custom Type7)/cupsMediaType 27 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User8/Benutzerdefinierter Typ 8: "<</ManualFeed false /MediaType (Custom Type8)/cupsMediaType 28 /DeferredMediaSelection true >> setpagedevice"
+*CloseUI: *MediaType
+
+*CloseGroup: MediaOptions/Medientyp
+
+*RequiresPageRegion All: True
+
+*% PPD Version Info 
+*OpenUI *KCVersion/PPD Version: PickOne
+*OrderDependency: 25 AnySetup *KCVersion
+*DefaultKCVersion: Default
+*KCVersion Default/1.1203 [03-23-2012]: ""
+*CloseUI: *KCVersion
+
+*% Font Information
+*DefaultFont: Courier
+*Font AvantGarde-Book: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-BookOblique: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-Demi: Standard "(001.007S)" Standard ROM
+*Font AvantGarde-DemiOblique: Standard "(001.007S)" Standard ROM
+*Font Bookman-Light: Standard "(001.004S)" Standard ROM
+*Font Bookman-LightItalic: Standard "(001.004S)" Standard ROM
+*Font Bookman-Demi: Standard "(001.004S)" Standard ROM
+*Font Bookman-DemiItalic: Standard "(001.004S)" Standard ROM
+*Font Courier: Standard "(002.004S)" Standard ROM
+*Font Courier-Oblique: Standard "(002.004S)" Standard ROM
+*Font Courier-Bold: Standard "(002.004S)" Standard ROM
+*Font Courier-BoldOblique: Standard "(002.004S)" Standard ROM
+*Font Helvetica: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Roman: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Italic: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Bold: Standard "(001.009S)" Standard ROM
+*Font NewCenturySchlbk-BoldItalic: Standard "(001.007S)" Standard ROM
+*Font Palatino-Roman: Standard "(001.005S)" Standard ROM
+*Font Palatino-Italic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Bold: Standard "(001.005S)" Standard ROM
+*Font Palatino-BoldItalic: Standard "(001.005S)" Standard ROM
+*Font Symbol: Special "(001.007S)" Special ROM
+*Font Times-Roman: Standard "(001.007S)" Standard ROM
+*Font Times-Italic: Standard "(001.007S)" Standard ROM
+*Font Times-Bold: Standard "(001.007S)" Standard ROM
+*Font Times-BoldItalic: Standard "(001.009S)" Standard ROM
+*Font ZapfChancery-MediumItalic: Standard "(001.007S)" Standard ROM
+*Font ZapfDingbats: Special "(001.004S)" Special ROM
+*Font Albertus-Medium: Standard "(001.008S)" Standard ROM
+*Font Albertus-ExtraBold: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Italic: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial: Standard "(001.008S)" Standard ROM
+*Font Arial-Italic: Standard "(001.008S)" Standard ROM
+*Font Arial-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGOmega: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Italic: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Bold: Standard "(001.008S)" Standard ROM
+*Font CGOmega-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGTimes: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Italic: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Bold: Standard "(001.008S)" Standard ROM
+*Font CGTimes-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Clarendon-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Coronet: Standard "(001.008S)" Standard ROM
+*Font CourierHP: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Italic: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Bold: Standard "(001.008S)" Standard ROM
+*Font CourierHP-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Garamond-Antiqua: Standard "(001.008S)" Standard ROM
+*Font Garamond-Halbfett: Standard "(001.008S)" Standard ROM
+*Font Garamond-Kursiv: Standard "(001.008S)" Standard ROM
+*Font Garamond-KursivHalbfett: Standard "(001.008S)" Standard ROM
+*Font LetterGothic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Italic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Bold: Standard "(001.008S)" Standard ROM
+*Font Marygold: Standard "(001.008S)" Standard ROM
+*Font SymbolMT: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Italic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Wingdings-Regular: Special "(001.008S)" Special ROM
+*?FontQuery: "
+  save
+  /str 80 string dup 0 (fonts/) putinterval def
+  {count 1 gt
+    { exch dup str 6 94 getinterval cvs
+      (/) print print (:) print
+      FontDirectory exch known
+      {(Yes)}{(No)} ifelse =
+    }{exit} ifelse
+  } bind loop (*)
+  = flush restore"
+*End
+*?FontList: "save FontDirectory { pop == } bind forall flush (*) = flush restore"
+*% Printer Messages
+*Message: "%%[ exitserver: permanent state may be changed ]%%"
+*Message: "%%[ Flushing: rest of job (to end-of-file) will be ignored ]%%"
+*Message: "\FontName\ not found, using Courier"
+
+*% Status (format: %%[ status: <one of these> ]%% )
+*Status: "warming up"/warming up
+*Status: "idle"/idle
+*Status: "busy"/busy
+*Status: "waiting"/waiting
+*Status: "printing"/printing
+*Status: "initializing"/initializing
+*Status: "printing test page"/printing test page
+*% Printer Error (format: %%[ PrinterError: <one of these> ]%% )
+*PrinterError: "paper entry misfeed"
+*PrinterError: "cover open"
+*PrinterError: "no paper tray"
+*PrinterError: "out of paper"
+*PrinterError: "toner low (halt)"
+*PrinterError: "warming up"
+*PrinterError: "other reason"
+*PrinterError: "video interface mode"
+*PrinterError: "offline"
+*PrinterError: "toner low (warning)"
+
+*% Input Sources (format: %%[ status: <stat>;source:<one of these> ]%% )
+*Source: "Serial"
+*Source: "Parallel"
+*Source: "LocalTalk"
+*Source: "Option"
+
+*%  End of PPD file for Kyocera FS-1041 (European German)

--- a/Kyocera_FS-1061DNGDI.ppd
+++ b/Kyocera_FS-1061DNGDI.ppd
@@ -1,0 +1,624 @@
+*PPD-Adobe: "4.3"
+*%=============================================================================
+*%
+*%  PPD file for Kyocera FS-1061DN (European German)
+*%  Linux Version
+*%
+*% (C) 2012 KYOCERA Document Solutions Inc.
+*%
+*%  Permission is granted for redistribution of this file as long as this
+*%  copyright notice is intact and the contents of the file are not altered
+*%  in any way from their original form.
+*%
+*%  Permission is hereby granted, free of charge, to any person obtaining
+*%  a copy of this software and associated documentation files (the
+*%  "Software"), to deal in the Software without restriction, including
+*%  without limitation the rights to use, copy, modify, merge, publish,
+*%  distribute, sublicense, and/or sell copies of the Software, and to
+*%  permit persons to whom the Software is furnished to do so, subject to
+*%  the following conditions:
+*%
+*%  The above copyright notice and this permission notice shall be
+*%  included in all copies or substantial portions of the Software.
+*%
+*%  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+*%  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+*%  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+*%  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+*%  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+*%  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+*%  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*%
+*%  [this is the MIT open source license -- see www.opensource.org]
+*%
+*%=============================================================================
+
+*FileVersion: "1.1203"
+*FormatVersion: "4.3"
+*LanguageEncoding: ISOLatin1
+*LanguageVersion: German
+*Product: "(FS-1061DN)"
+*PSVersion: "(3011.103) 1"
+*Manufacturer: "Kyocera"
+*ModelName: "Kyocera FS-1061DN KPSL"
+*ShortNickName: "Kyocera FS-1061DN (KPSL)"
+*NickName: "Kyocera FS-1061DN (KPSL)"
+*PCFileName: "KC1061EG.PPD"
+
+*1284DeviceID: "MDL:FS-1061DN;MFG:Kyocera"
+
+*cupsVersion: 1.2
+*cupsManualCopies: False
+*cupsModelNumber: 0
+*cupsSNMPSupplies: False
+
+*cupsFilter: "application/vnd.cups-raster 0 /usr/lib/cups/filter/rastertokpsl"
+
+*% Basic Device Capabilities
+*LandscapeOrientation: Plus90
+*AccurateScreensSupport: True
+*LanguageLevel: "3"
+*ColorDevice: False
+*ContoneOnly: False
+*DefaultColorSpace: Gray
+*TTRasterizer: Type42
+*?TTRasterizer: "
+  save
+  42 /FontType resourcestatus
+  { pop pop (Type42) }{ (None) } ifelse
+  = flush restore"
+*End
+
+*Throughput: "25"
+
+*% System Management
+*SuggestedJobTimeout: "0"
+*SuggestedManualFeedTimeout: "0"
+*SuggestedWaitTimeout: "120"
+*PrintPSErrors: True
+
+*Password: "0"
+
+*ExitServer: "
+  count 0 eq {true}
+  {dup statusdict /checkpassword get exec not} ifelse
+  {(WARNING : Cannot perform the exitserver command.) =
+    (Password supplied is not valid.) =
+    (Please contact the author of this software.) = flush quit} if
+  serverdict /exitserver get exec"
+*End
+
+*Reset: "
+  count 0 eq { true }
+  {dup statusdict /checkpassword get exec not} ifelse
+  {(WARNING : Cannot perform the exitserver command.) =
+    (Password supplied is not valid.) =
+    (Please contact the author of this software.) = flush quit} if
+  serverdict /exitserver get exec
+  systemdict /quit get exec
+  (WARNING : Printer Reset Failed.) = flush"
+*End
+
+*% Protocols
+*Protocols: TBCP
+
+*1284Modes Parallel: Compat Nibble ECP
+
+*% Virtual Memory
+*FreeVM: "32000000"
+
+*% Constraints
+*UIConstraints: *Duplex *PageSize Statement
+*UIConstraints: *PageSize Statement *Duplex DuplexTumble
+*UIConstraints: *PageSize Statement *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion Statement
+*UIConstraints: *PageRegion Statement *Duplex DuplexTumble
+*UIConstraints: *PageRegion Statement *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageSize A5
+*UIConstraints: *PageSize A5 *Duplex DuplexTumble
+*UIConstraints: *PageSize A5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion A5
+*UIConstraints: *PageRegion A5 *Duplex DuplexTumble
+*UIConstraints: *PageRegion A5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageSize ISOB5
+*UIConstraints: *PageSize ISOB5 *Duplex DuplexTumble
+*UIConstraints: *PageSize ISOB5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion ISOB5
+*UIConstraints: *PageRegion ISOB5 *Duplex DuplexTumble
+*UIConstraints: *PageRegion ISOB5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageSize EnvC5
+*UIConstraints: *PageSize EnvC5 *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvC5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion EnvC5
+*UIConstraints: *PageRegion EnvC5 *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvC5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageSize B5
+*UIConstraints: *PageSize B5 *Duplex DuplexTumble
+*UIConstraints: *PageSize B5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion B5
+*UIConstraints: *PageRegion B5 *Duplex DuplexTumble
+*UIConstraints: *PageRegion B5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *MediaType Labels
+*UIConstraints: *MediaType Labels *Duplex DuplexTumble
+*UIConstraints: *MediaType Labels *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *MediaType Vellum
+*UIConstraints: *MediaType Vellum *Duplex DuplexTumble
+*UIConstraints: *MediaType Vellum *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *MediaType Envelope
+*UIConstraints: *MediaType Envelope *Duplex DuplexTumble
+*UIConstraints: *MediaType Envelope *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *MediaType Cardstock
+*UIConstraints: *MediaType Cardstock *Duplex DuplexTumble
+*UIConstraints: *MediaType Cardstock *Duplex DuplexNoTumble
+*UIConstraints: *MediaType Labels *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Labels
+*UIConstraints: *MediaType Vellum *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Vellum
+*UIConstraints: *MediaType Envelope *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Envelope
+*UIConstraints: *MediaType Cardstock *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Cardstock
+*NonUIConstraints: *Duplex *CustomPageSize True
+*NonUIConstraints: *CustomPageSize True *Duplex
+*UIConstraints: *Duplex *PageSize A6
+*UIConstraints: *PageSize A6 *Duplex DuplexTumble
+*UIConstraints: *PageSize A6 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion A6
+*UIConstraints: *PageRegion A6 *Duplex DuplexTumble
+*UIConstraints: *PageRegion A6 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageSize EnvPersonal
+*UIConstraints: *PageSize EnvPersonal *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvPersonal *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion EnvPersonal
+*UIConstraints: *PageRegion EnvPersonal *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvPersonal *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageSize Env9
+*UIConstraints: *PageSize Env9 *Duplex DuplexTumble
+*UIConstraints: *PageSize Env9 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion Env9
+*UIConstraints: *PageRegion Env9 *Duplex DuplexTumble
+*UIConstraints: *PageRegion Env9 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageSize Env10
+*UIConstraints: *PageSize Env10 *Duplex DuplexTumble
+*UIConstraints: *PageSize Env10 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion Env10
+*UIConstraints: *PageRegion Env10 *Duplex DuplexTumble
+*UIConstraints: *PageRegion Env10 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageSize EnvMonarch
+*UIConstraints: *PageSize EnvMonarch *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvMonarch *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion EnvMonarch
+*UIConstraints: *PageRegion EnvMonarch *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvMonarch *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageSize EnvDL
+*UIConstraints: *PageSize EnvDL *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvDL *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion EnvDL
+*UIConstraints: *PageRegion EnvDL *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvDL *Duplex DuplexNoTumble
+
+*OpenGroup: GraphicsOptions/Grafiken
+
+*% Resolution 
+*OpenUI *Resolution/Aufl<F6>sung: PickOne
+*OrderDependency: 10 AnySetup *Resolution
+*DefaultResolution: 600dpi
+*Resolution 600dpi/600 dpi: "<< /HWResolution [600 600] /PreRenderingEnhance false >> setpagedevice"
+*CloseUI: *Resolution
+
+*% Color Model
+*OpenUI *ColorModel/Farbmodus: PickOne
+*OrderDependency: 10 AnySetup *ColorModel
+*DefaultColorModel: Gray
+*ColorModel Gray/Schwarz/Wei<DF>: "<< /ProcessColorModel /DeviceGray /cupsColorOrder 0/cupsColorSpace 3/cupsBitsPerColor 8/cupsCompression 1 >> setpagedevice"
+*CloseUI: *ColorModel
+
+*CloseGroup: GraphicsOptions/Grafiken
+
+*% Halftone Information 
+*DefaultHalftoneType: 1
+*ScreenFreq: "37.5"
+*ScreenAngle: "45.0"
+*ResScreenFreq 600dpi: "37.5"
+*ResScreenAngle 600dpi: "45.0"
+
+*DefaultScreenProc: Ellipse
+*ScreenProc Dot: "
+  {abs exch abs 2 copy add 1 gt
+  {1 sub dup mul exch 1 sub dup mul add 1 sub}
+  {dup mul exch dup mul add 1 exch sub} ifelse}"
+*End
+*ScreenProc Line: "{pop}"
+*ScreenProc Ellipse: "{dup 5 mul 8 div mul exch dup mul exch add sqrt 1 exch sub}"
+*DefaultTransfer: Null
+*Transfer Null: "{}"
+*Transfer Null.Inverse: "{1 exch sub}"
+
+*% Paper Handling 
+*% Page Size Definitions
+*OpenUI *PageSize: PickOne
+*OrderDependency: 40 AnySetup *PageSize
+*DefaultPageSize: A4
+*PageSize A4/A4: "<< /Policies << /PageSize 7 >> /PageSize [595 842] /ImagingBBox null >> setpagedevice"
+*PageSize A5/A5: "<< /Policies << /PageSize 7 >> /PageSize [421 595] /ImagingBBox null >> setpagedevice"
+*PageSize A6/A6: "<< /Policies << /PageSize 7 >> /PageSize [297 421] /ImagingBBox null >> setpagedevice"
+*PageSize B5/B5 (JIS): "<< /Policies << /PageSize 7 >> /PageSize [516 729] /ImagingBBox null >> setpagedevice"
+*PageSize ISOB5/B5 (ISO): "<< /Policies << /PageSize 7 >> /PageSize [499 708] /ImagingBBox null >> setpagedevice"
+*PageSize OficioII/Oficio II: "<< /Policies << /PageSize 7 >> /PageSize [612 936] /ImagingBBox null >> setpagedevice"
+*PageSize Folio/Folio (210 x 330mm): "<< /Policies << /PageSize 7 >> /PageSize [595 935] /ImagingBBox null >> setpagedevice"
+*PageSize Statement/Statement: "<< /Policies << /PageSize 7 >> /PageSize [396 612] /ImagingBBox null >> setpagedevice"
+*PageSize P16K/16K: "<< /Policies << /PageSize 7 >> /PageSize [558 774] /ImagingBBox null >> setpagedevice"
+*PageSize OficioMX/216 x 340 mm: "<< /Policies << /PageSize 7 >> /PageSize [612 964] /ImagingBBox null >> setpagedevice"
+*PageSize Letter/US-Letter: "<< /Policies << /PageSize 7 >> /PageSize [612 792] /ImagingBBox null >> setpagedevice"
+*PageSize Legal/US-Legal: "<< /Policies << /PageSize 7 >> /PageSize [612 1008] /ImagingBBox null >> setpagedevice"
+*PageSize Executive/US-Executive: "<< /Policies << /PageSize 7 >> /PageSize [522 756] /ImagingBBox null >> setpagedevice"
+*PageSize EnvPersonal/Umschlag #6: "<< /Policies << /PageSize 7 >> /PageSize [261 468] /ImagingBBox null >> setpagedevice"
+*PageSize Env9/Umschlag #9: "<< /Policies << /PageSize 7 >> /PageSize [279 639] /ImagingBBox null >> setpagedevice"
+*PageSize Env10/Umschlag #10: "<< /Policies << /PageSize 7 >> /PageSize [297 684] /ImagingBBox null >> setpagedevice"
+*PageSize EnvMonarch/Umschlag US-Monarch: "<< /Policies << /PageSize 7 >> /PageSize [279 540] /ImagingBBox null >> setpagedevice"
+*PageSize EnvDL/Umschlag DL: "<< /Policies << /PageSize 7 >> /PageSize [312 624] /ImagingBBox null >> setpagedevice"
+*PageSize EnvC5/Umschlag C5: "<< /Policies << /PageSize 7 >> /PageSize [459 649] /ImagingBBox null >> setpagedevice"
+*CloseUI: *PageSize
+
+*% Page Region Definitions for Frame Buffer
+*OpenUI *PageRegion: PickOne
+*OrderDependency: 40 AnySetup *PageRegion
+*DefaultPageRegion: A4
+*PageRegion A4/A4: "<< /Policies << /PageSize 7 >> /PageSize [595 842] /ImagingBBox null >> setpagedevice"
+*PageRegion A5/A5: "<< /Policies << /PageSize 7 >> /PageSize [421 595] /ImagingBBox null >> setpagedevice"
+*PageRegion A6/A6: "<< /Policies << /PageSize 7 >> /PageSize [297 421] /ImagingBBox null >> setpagedevice"
+*PageRegion B5/B5 (JIS): "<< /Policies << /PageSize 7 >> /PageSize [516 729] /ImagingBBox null >> setpagedevice"
+*PageRegion ISOB5/B5 (ISO): "<< /Policies << /PageSize 7 >> /PageSize [499 708] /ImagingBBox null >> setpagedevice"
+*PageRegion Letter/US-Letter: "<< /Policies << /PageSize 7 >> /PageSize [612 792] /ImagingBBox null >> setpagedevice"
+*PageRegion Legal/US-Legal: "<< /Policies << /PageSize 7 >> /PageSize [612 1008] /ImagingBBox null >> setpagedevice"
+*PageRegion Executive/US-Executive: "<< /Policies << /PageSize 7 >> /PageSize [522 756] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvPersonal/Umschlag #6: "<< /Policies << /PageSize 7 >> /PageSize [261 468] /ImagingBBox null >> setpagedevice"
+*PageRegion Env9/Umschlag #9: "<< /Policies << /PageSize 7 >> /PageSize [279 639] /ImagingBBox null >> setpagedevice"
+*PageRegion Env10/Umschlag #10: "<< /Policies << /PageSize 7 >> /PageSize [297 684] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvMonarch/Umschlag US-Monarch: "<< /Policies << /PageSize 7 >> /PageSize [279 540] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvDL/Umschlag DL: "<< /Policies << /PageSize 7 >> /PageSize [312 624] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvC5/Umschlag C5: "<< /Policies << /PageSize 7 >> /PageSize [459 649] /ImagingBBox null >> setpagedevice"
+*PageRegion OficioII/Oficio II: "<< /Policies << /PageSize 7 >> /PageSize [612 936] /ImagingBBox null >> setpagedevice"
+*PageRegion Folio/Folio (210 x 330mm): "<< /Policies << /PageSize 7 >> /PageSize [595 935] /ImagingBBox null >> setpagedevice"
+*PageRegion Statement/Statement: "<< /Policies << /PageSize 7 >> /PageSize [396 612] /ImagingBBox null >> setpagedevice"
+*PageRegion P16K/16K: "<< /Policies << /PageSize 7 >> /PageSize [558 774] /ImagingBBox null >> setpagedevice"
+*PageRegion OficioMX/216 x 340 mm: "<< /Policies << /PageSize 7 >> /PageSize [612 964] /ImagingBBox null >> setpagedevice"
+*CloseUI: *PageRegion
+
+*% Imageable Area Definitions
+*DefaultImageableArea: A4
+*ImageableArea A4/A4: "12 10 583 832"
+*ImageableArea A5/A5: "12 10 409 585"
+*ImageableArea A6/A6: "12 10 285 411"
+*ImageableArea B5/B5 (JIS): "21 10 495 719"
+*ImageableArea ISOB5/B5 (ISO): "12 12 487 696"
+*ImageableArea OficioII/Oficio II: "12 12 600 924"
+*ImageableArea Folio/Folio (210 x 330mm): "12 12 583 923"
+*ImageableArea Statement/Statement: "12 12 384 600"
+*ImageableArea P16K/16K: "12 12 547 763"
+*ImageableArea OficioMX/216 x 340 mm: "12 12 600 952"
+*ImageableArea Letter/US-Letter: "12 08 600 776"
+*ImageableArea Legal/US-Legal: "12 08 600 1000"
+*ImageableArea Executive/US-Executive: "12 08 510 748"
+*ImageableArea EnvPersonal/Umschlag #6: "12 08 249 460"
+*ImageableArea Env9/Umschlag #9: "12 08 267 631"
+*ImageableArea Env10/Umschlag #10: "12 08 285 676"
+*ImageableArea EnvMonarch/Umschlag US-Monarch: "12 08 267 532"
+*ImageableArea EnvDL/Umschlag DL: "12 10 300 614"
+*ImageableArea EnvC5/Umschlag C5: "12 10 447 639"
+*% Physical Dimensions of Media
+*DefaultPaperDimension: A4
+*PaperDimension A4/A4: "595 842"
+*PaperDimension A5/A5: "421 595"
+*PaperDimension A6/A6: "297 421"
+*PaperDimension B5/B5 (JIS): "516 729"
+*PaperDimension ISOB5/B5 (ISO): "499 708"
+*PaperDimension OficioII/Oficio II: "612 936"
+*PaperDimension Folio/Folio (210 x 330mm): "595 935"
+*PaperDimension Statement/Statement: "396 612"
+*PaperDimension P16K/16K: "558 774"
+*PaperDimension OficioMX/216 x 340 mm: "612 964"
+*PaperDimension Letter/US-Letter: "612 792"
+*PaperDimension Legal/US-Legal: "612 1008"
+*PaperDimension Executive/US-Executive: "522 756"
+*PaperDimension EnvPersonal/Umschlag #6: "261 468"
+*PaperDimension Env9/Umschlag #9: "279 639"
+*PaperDimension Env10/Umschlag #10: "297 684"
+*PaperDimension EnvMonarch/Umschlag US-Monarch: "279 540"
+*PaperDimension EnvDL/Umschlag DL: "312 624"
+*PaperDimension EnvC5/Umschlag C5: "459 649"
+
+*% Custom Page Size Definitions
+*% Smallest = A6, Largest = LEGAL
+
+*VariablePaperSize: True
+*LeadingEdge Short: ""
+*DefaultLeadingEdge: Short
+*HWMargins: 12 12 12 12
+*MaxMediaWidth: "612"
+*MaxMediaHeight: "1008"
+*NonUIOrderDependency: 40 AnySetup *CustomPageSize
+*CustomPageSize True: "
+  pop pop pop
+  << /PageSize [ 5 -2 roll ] /ImagingBBox null
+     /DeferredMediaSelection true
+  >> setpagedevice"
+*End
+*ParamCustomPageSize Width: 1 points 278 612
+*ParamCustomPageSize Height: 2 points 420 1008
+*ParamCustomPageSize WidthOffset: 3 points 0 0
+*ParamCustomPageSize HeightOffset: 4 points 0 0
+*ParamCustomPageSize Orientation: 5 int 1 1
+
+*OpenGroup: MFFeedOptions/Papierzufuhr Handeinzug
+
+*% Manual Feed Switch Definitions
+*OpenUI *Feeding/Papierzufuhr Handeinzug: PickOne
+*OrderDependency: 40 AnySetup *Feeding
+*DefaultFeeding: Off
+*Feeding On/Ein: ""
+*Feeding Off/Aus: ""
+*CloseUI: *Feeding
+
+*CloseGroup: MFFeedOptions/Papierzufuhr Handeinzug
+
+*OpenGroup: SpeedOptions/Modus reduzierter Geschwindigkeit
+
+*% Engine Speed Definitions
+*OpenUI *EngineSpeed/Modus reduzierter Geschwindigkeit: PickOne
+*OrderDependency: 40 AnySetup *EngineSpeed
+*DefaultEngineSpeed: Off
+*EngineSpeed On/Ein: ""
+*EngineSpeed Off/Aus: ""
+*CloseUI: *EngineSpeed
+
+*CloseGroup: SpeedOptions/Modus reduzierter Geschwindigkeit
+
+*OpenGroup: CaBrightness/Helligkeit
+
+*% Adjustment Definitions
+*OpenUI *CaBrightness/Helligkeit: PickOne
+*OrderDependency: 11 AnySetup *CaBrightness
+*DefaultCaBrightness: 0
+*CaBrightness -100/-100: ""
+*CaBrightness -90/-90: ""
+*CaBrightness -80/-80: ""
+*CaBrightness -70/-70: ""
+*CaBrightness -60/-60: ""
+*CaBrightness -50/-50: ""
+*CaBrightness -40/-40: ""
+*CaBrightness -30/-30: ""
+*CaBrightness -20/-20: ""
+*CaBrightness -10/-10: ""
+*CaBrightness 0/0: ""
+*CaBrightness 10/10: ""
+*CaBrightness 20/20: ""
+*CaBrightness 30/30: ""
+*CaBrightness 40/40: ""
+*CaBrightness 50/50: ""
+*CaBrightness 60/60: ""
+*CaBrightness 70/70: ""
+*CaBrightness 80/80: ""
+*CaBrightness 90/90: ""
+*CaBrightness 100/100: ""
+*CloseUI: *CaBrightness
+
+*CloseGroup: CaBrightness/Helligkeit
+
+*OpenGroup: CaContrast/Kontrast
+
+*% Adjustment Definitions
+*OpenUI *CaContrast/Kontrast: PickOne
+*OrderDependency: 12 AnySetup *CaContrast
+*DefaultCaContrast: 0
+*CaContrast -100/-100: ""
+*CaContrast -90/-90: ""
+*CaContrast -80/-80: ""
+*CaContrast -70/-70: ""
+*CaContrast -60/-60: ""
+*CaContrast -50/-50: ""
+*CaContrast -40/-40: ""
+*CaContrast -30/-30: ""
+*CaContrast -20/-20: ""
+*CaContrast -10/-10: ""
+*CaContrast 0/0: ""
+*CaContrast 10/10: ""
+*CaContrast 20/20: ""
+*CaContrast 30/30: ""
+*CaContrast 40/40: ""
+*CaContrast 50/50: ""
+*CaContrast 60/60: ""
+*CaContrast 70/70: ""
+*CaContrast 80/80: ""
+*CaContrast 90/90: ""
+*CaContrast 100/100: ""
+*CloseUI: *CaContrast
+
+*CloseGroup: CaContrast/Kontrast
+
+*OpenGroup: MediaOptions/Medientyp
+
+*% MediaType Definitions
+*OpenUI *MediaType/Medientyp: PickOne
+*OrderDependency: 95 AnySetup *MediaType
+*DefaultMediaType: PrnDef
+*MediaType PrnDef/Automatische Medienauswahl: "<</cupsMediaType 0 >> setpagedevice"
+*MediaType Plain/Normalpapier: "<</ManualFeed false /MediaType (Plain)/cupsMediaType 1 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Labels/Etiketten: "<</ManualFeed false /MediaType (Labels)/cupsMediaType 4 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Letterhead/Briefkopf: "<</ManualFeed false /MediaType (Letterhead)/cupsMediaType 9 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Bond/Feinpapier: "<</ManualFeed false /MediaType (Bond)/cupsMediaType 5 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Color/Mehrfarbig: "<</ManualFeed false /MediaType (Color)/cupsMediaType 10 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Preprinted/Vorgedruckt: "<</ManualFeed false /MediaType (Preprinted)/cupsMediaType 3 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Prepunched/Vorgelocht: "<</ManualFeed false /MediaType (Prepunched)/cupsMediaType 11 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Recycled/Recycling-Papier: "<</ManualFeed false /MediaType (Recycled)/cupsMediaType 6 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Cardstock/Karteikarte: "<</ManualFeed false /MediaType (Card Stock)/cupsMediaType 13 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Vellum/Pergament: "<</ManualFeed false /MediaType (Vellum)/cupsMediaType 7 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Envelope/Umschlag: "<</ManualFeed false /MediaType (Envelope)/cupsMediaType 12 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Rough/Grobpapier: "<</ManualFeed false /MediaType (Rough)/cupsMediaType 8 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Thick/Dick: "<</ManualFeed false /MediaType (Thick)/cupsMediaType 16 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Highqlty/Hohe Qualit<E4>t: "<</ManualFeed false /MediaType (Fine)/cupsMediaType 17 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User1/Benutzerdefinierter Typ 1: "<</ManualFeed false /MediaType (Custom Type1)/cupsMediaType 21 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User2/Benutzerdefinierter Typ 2: "<</ManualFeed false /MediaType (Custom Type2)/cupsMediaType 22 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User3/Benutzerdefinierter Typ 3: "<</ManualFeed false /MediaType (Custom Type3)/cupsMediaType 23 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User4/Benutzerdefinierter Typ 4: "<</ManualFeed false /MediaType (Custom Type4)/cupsMediaType 24 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User5/Benutzerdefinierter Typ 5: "<</ManualFeed false /MediaType (Custom Type5)/cupsMediaType 25 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User6/Benutzerdefinierter Typ 6: "<</ManualFeed false /MediaType (Custom Type6)/cupsMediaType 26 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User7/Benutzerdefinierter Typ 7: "<</ManualFeed false /MediaType (Custom Type7)/cupsMediaType 27 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User8/Benutzerdefinierter Typ 8: "<</ManualFeed false /MediaType (Custom Type8)/cupsMediaType 28 /DeferredMediaSelection true >> setpagedevice"
+*CloseUI: *MediaType
+
+*CloseGroup: MediaOptions/Medientyp
+
+*RequiresPageRegion All: True
+
+*% Duplex Definitions
+*OpenUI *Duplex/Duplex: PickOne
+*OrderDependency: 50 AnySetup *Duplex
+*DefaultDuplex: None
+*Duplex None/Keine: "<</Duplex false /Tumble false>> setpagedevice"
+*Duplex DuplexTumble/Binden Kurze Seite: "<</Duplex true /Tumble true>> setpagedevice"
+*Duplex DuplexNoTumble/Binden Lange Seite: "<</Duplex true /Tumble false>> setpagedevice"
+*?Duplex: "
+  save
+  statusdict begin
+  duplexmode
+  {tumble {(DuplexTumble)}{(DuplexNoTumble)} ifelse}
+  {(None)} ifelse
+  = flush end restore"
+*End
+*CloseUI: *Duplex
+
+*% PPD Version Info 
+*OpenUI *KCVersion/PPD Version: PickOne
+*OrderDependency: 25 AnySetup *KCVersion
+*DefaultKCVersion: Default
+*KCVersion Default/1.1203 [03-23-2012]: ""
+*CloseUI: *KCVersion
+
+*% Font Information
+*DefaultFont: Courier
+*Font AvantGarde-Book: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-BookOblique: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-Demi: Standard "(001.007S)" Standard ROM
+*Font AvantGarde-DemiOblique: Standard "(001.007S)" Standard ROM
+*Font Bookman-Light: Standard "(001.004S)" Standard ROM
+*Font Bookman-LightItalic: Standard "(001.004S)" Standard ROM
+*Font Bookman-Demi: Standard "(001.004S)" Standard ROM
+*Font Bookman-DemiItalic: Standard "(001.004S)" Standard ROM
+*Font Courier: Standard "(002.004S)" Standard ROM
+*Font Courier-Oblique: Standard "(002.004S)" Standard ROM
+*Font Courier-Bold: Standard "(002.004S)" Standard ROM
+*Font Courier-BoldOblique: Standard "(002.004S)" Standard ROM
+*Font Helvetica: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Roman: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Italic: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Bold: Standard "(001.009S)" Standard ROM
+*Font NewCenturySchlbk-BoldItalic: Standard "(001.007S)" Standard ROM
+*Font Palatino-Roman: Standard "(001.005S)" Standard ROM
+*Font Palatino-Italic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Bold: Standard "(001.005S)" Standard ROM
+*Font Palatino-BoldItalic: Standard "(001.005S)" Standard ROM
+*Font Symbol: Special "(001.007S)" Special ROM
+*Font Times-Roman: Standard "(001.007S)" Standard ROM
+*Font Times-Italic: Standard "(001.007S)" Standard ROM
+*Font Times-Bold: Standard "(001.007S)" Standard ROM
+*Font Times-BoldItalic: Standard "(001.009S)" Standard ROM
+*Font ZapfChancery-MediumItalic: Standard "(001.007S)" Standard ROM
+*Font ZapfDingbats: Special "(001.004S)" Special ROM
+*Font Albertus-Medium: Standard "(001.008S)" Standard ROM
+*Font Albertus-ExtraBold: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Italic: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial: Standard "(001.008S)" Standard ROM
+*Font Arial-Italic: Standard "(001.008S)" Standard ROM
+*Font Arial-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGOmega: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Italic: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Bold: Standard "(001.008S)" Standard ROM
+*Font CGOmega-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGTimes: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Italic: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Bold: Standard "(001.008S)" Standard ROM
+*Font CGTimes-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Clarendon-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Coronet: Standard "(001.008S)" Standard ROM
+*Font CourierHP: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Italic: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Bold: Standard "(001.008S)" Standard ROM
+*Font CourierHP-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Garamond-Antiqua: Standard "(001.008S)" Standard ROM
+*Font Garamond-Halbfett: Standard "(001.008S)" Standard ROM
+*Font Garamond-Kursiv: Standard "(001.008S)" Standard ROM
+*Font Garamond-KursivHalbfett: Standard "(001.008S)" Standard ROM
+*Font LetterGothic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Italic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Bold: Standard "(001.008S)" Standard ROM
+*Font Marygold: Standard "(001.008S)" Standard ROM
+*Font SymbolMT: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Italic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Wingdings-Regular: Special "(001.008S)" Special ROM
+*?FontQuery: "
+  save
+  /str 80 string dup 0 (fonts/) putinterval def
+  {count 1 gt
+    { exch dup str 6 94 getinterval cvs
+      (/) print print (:) print
+      FontDirectory exch known
+      {(Yes)}{(No)} ifelse =
+    }{exit} ifelse
+  } bind loop (*)
+  = flush restore"
+*End
+*?FontList: "save FontDirectory { pop == } bind forall flush (*) = flush restore"
+*% Printer Messages
+*Message: "%%[ exitserver: permanent state may be changed ]%%"
+*Message: "%%[ Flushing: rest of job (to end-of-file) will be ignored ]%%"
+*Message: "\FontName\ not found, using Courier"
+
+*% Status (format: %%[ status: <one of these> ]%% )
+*Status: "warming up"/warming up
+*Status: "idle"/idle
+*Status: "busy"/busy
+*Status: "waiting"/waiting
+*Status: "printing"/printing
+*Status: "initializing"/initializing
+*Status: "printing test page"/printing test page
+*% Printer Error (format: %%[ PrinterError: <one of these> ]%% )
+*PrinterError: "paper entry misfeed"
+*PrinterError: "cover open"
+*PrinterError: "no paper tray"
+*PrinterError: "out of paper"
+*PrinterError: "toner low (halt)"
+*PrinterError: "warming up"
+*PrinterError: "other reason"
+*PrinterError: "video interface mode"
+*PrinterError: "offline"
+*PrinterError: "toner low (warning)"
+
+*% Input Sources (format: %%[ status: <stat>;source:<one of these> ]%% )
+*Source: "Serial"
+*Source: "Parallel"
+*Source: "LocalTalk"
+*Source: "Option"
+
+*%  End of PPD file for Kyocera FS-1061DN (European German)

--- a/Kyocera_FS-1220MFPGDI.ppd
+++ b/Kyocera_FS-1220MFPGDI.ppd
@@ -1,0 +1,515 @@
+*PPD-Adobe: "4.3"
+*%=============================================================================
+*%
+*%  PPD file for Kyocera FS-1220MFP (European German)
+*%  Linux Version
+*%
+*% (C) 2012 KYOCERA Document Solutions Inc.
+*%
+*%  Permission is granted for redistribution of this file as long as this
+*%  copyright notice is intact and the contents of the file are not altered
+*%  in any way from their original form.
+*%
+*%  Permission is hereby granted, free of charge, to any person obtaining
+*%  a copy of this software and associated documentation files (the
+*%  "Software"), to deal in the Software without restriction, including
+*%  without limitation the rights to use, copy, modify, merge, publish,
+*%  distribute, sublicense, and/or sell copies of the Software, and to
+*%  permit persons to whom the Software is furnished to do so, subject to
+*%  the following conditions:
+*%
+*%  The above copyright notice and this permission notice shall be
+*%  included in all copies or substantial portions of the Software.
+*%
+*%  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+*%  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+*%  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+*%  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+*%  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+*%  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+*%  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*%
+*%  [this is the MIT open source license -- see www.opensource.org]
+*%
+*%=============================================================================
+
+*FileVersion: "1.1203"
+*FormatVersion: "4.3"
+*LanguageEncoding: ISOLatin1
+*LanguageVersion: German
+*Product: "(FS-1220MFP)"
+*PSVersion: "(3011.103) 1"
+*Manufacturer: "Kyocera"
+*ModelName: "Kyocera FS-1220MFP KPSL"
+*ShortNickName: "Kyocera FS-1220MFP (KPSL)"
+*NickName: "Kyocera FS-1220MFP (KPSL)"
+*PCFileName: "KC1220EG.PPD"
+
+*1284DeviceID: "MDL:FS-1220MFP;MFG:Kyocera"
+
+*cupsVersion: 1.2
+*cupsManualCopies: False
+*cupsModelNumber: 0
+*cupsSNMPSupplies: False
+
+*cupsFilter: "application/vnd.cups-raster 0 /usr/lib/cups/filter/rastertokpsl"
+
+*% Basic Device Capabilities
+*LandscapeOrientation: Plus90
+*AccurateScreensSupport: True
+*LanguageLevel: "3"
+*ColorDevice: False
+*ContoneOnly: False
+*DefaultColorSpace: Gray
+*TTRasterizer: Type42
+*?TTRasterizer: "
+  save
+  42 /FontType resourcestatus
+  { pop pop (Type42) }{ (None) } ifelse
+  = flush restore"
+*End
+
+*Throughput: "20"
+
+*% System Management
+*SuggestedJobTimeout: "0"
+*SuggestedManualFeedTimeout: "0"
+*SuggestedWaitTimeout: "120"
+*PrintPSErrors: True
+
+*Password: "0"
+
+*ExitServer: "
+  count 0 eq {true}
+  {dup statusdict /checkpassword get exec not} ifelse
+  {(WARNING : Cannot perform the exitserver command.) =
+    (Password supplied is not valid.) =
+    (Please contact the author of this software.) = flush quit} if
+  serverdict /exitserver get exec"
+*End
+
+*Reset: "
+  count 0 eq { true }
+  {dup statusdict /checkpassword get exec not} ifelse
+  {(WARNING : Cannot perform the exitserver command.) =
+    (Password supplied is not valid.) =
+    (Please contact the author of this software.) = flush quit} if
+  serverdict /exitserver get exec
+  systemdict /quit get exec
+  (WARNING : Printer Reset Failed.) = flush"
+*End
+
+*% Protocols
+*Protocols: TBCP
+
+*1284Modes Parallel: Compat Nibble ECP
+
+*% Virtual Memory
+*FreeVM: "32000000"
+
+*% Constraints
+*UIConstraints: *MediaType Labels *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Labels
+*UIConstraints: *MediaType Vellum *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Vellum
+*UIConstraints: *MediaType Envelope *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Envelope
+*UIConstraints: *MediaType Cardstock *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Cardstock
+
+*OpenGroup: GraphicsOptions/Grafiken
+
+*% Resolution 
+*OpenUI *Resolution/Aufl<F6>sung: PickOne
+*OrderDependency: 10 AnySetup *Resolution
+*DefaultResolution: 600dpi
+*Resolution 600dpi/600 dpi: "<< /HWResolution [600 600] /PreRenderingEnhance false >> setpagedevice"
+*CloseUI: *Resolution
+
+*% Color Model
+*OpenUI *ColorModel/Farbmodus: PickOne
+*OrderDependency: 10 AnySetup *ColorModel
+*DefaultColorModel: Gray
+*ColorModel Gray/Schwarz/Wei<DF>: "<< /ProcessColorModel /DeviceGray /cupsColorOrder 0/cupsColorSpace 3/cupsBitsPerColor 8/cupsCompression 1 >> setpagedevice"
+*CloseUI: *ColorModel
+
+*CloseGroup: GraphicsOptions/Grafiken
+
+*% Halftone Information 
+*DefaultHalftoneType: 1
+*ScreenFreq: "37.5"
+*ScreenAngle: "45.0"
+*ResScreenFreq 600dpi: "37.5"
+*ResScreenAngle 600dpi: "45.0"
+
+*DefaultScreenProc: Ellipse
+*ScreenProc Dot: "
+  {abs exch abs 2 copy add 1 gt
+  {1 sub dup mul exch 1 sub dup mul add 1 sub}
+  {dup mul exch dup mul add 1 exch sub} ifelse}"
+*End
+*ScreenProc Line: "{pop}"
+*ScreenProc Ellipse: "{dup 5 mul 8 div mul exch dup mul exch add sqrt 1 exch sub}"
+*DefaultTransfer: Null
+*Transfer Null: "{}"
+*Transfer Null.Inverse: "{1 exch sub}"
+
+*% Paper Handling 
+*% Page Size Definitions
+*OpenUI *PageSize: PickOne
+*OrderDependency: 40 AnySetup *PageSize
+*DefaultPageSize: A4
+*PageSize A4/A4: "<< /Policies << /PageSize 7 >> /PageSize [595 842] /ImagingBBox null >> setpagedevice"
+*PageSize A5/A5: "<< /Policies << /PageSize 7 >> /PageSize [421 595] /ImagingBBox null >> setpagedevice"
+*PageSize A6/A6: "<< /Policies << /PageSize 7 >> /PageSize [297 421] /ImagingBBox null >> setpagedevice"
+*PageSize B5/B5 (JIS): "<< /Policies << /PageSize 7 >> /PageSize [516 729] /ImagingBBox null >> setpagedevice"
+*PageSize ISOB5/B5 (ISO): "<< /Policies << /PageSize 7 >> /PageSize [499 708] /ImagingBBox null >> setpagedevice"
+*PageSize OficioII/Oficio II: "<< /Policies << /PageSize 7 >> /PageSize [612 936] /ImagingBBox null >> setpagedevice"
+*PageSize Folio/Folio (210 x 330mm): "<< /Policies << /PageSize 7 >> /PageSize [595 935] /ImagingBBox null >> setpagedevice"
+*PageSize Statement/Statement: "<< /Policies << /PageSize 7 >> /PageSize [396 612] /ImagingBBox null >> setpagedevice"
+*PageSize P16K/16K: "<< /Policies << /PageSize 7 >> /PageSize [558 774] /ImagingBBox null >> setpagedevice"
+*PageSize OficioMX/216 x 340 mm: "<< /Policies << /PageSize 7 >> /PageSize [612 964] /ImagingBBox null >> setpagedevice"
+*PageSize Letter/US-Letter: "<< /Policies << /PageSize 7 >> /PageSize [612 792] /ImagingBBox null >> setpagedevice"
+*PageSize Legal/US-Legal: "<< /Policies << /PageSize 7 >> /PageSize [612 1008] /ImagingBBox null >> setpagedevice"
+*PageSize Executive/US-Executive: "<< /Policies << /PageSize 7 >> /PageSize [522 756] /ImagingBBox null >> setpagedevice"
+*PageSize EnvPersonal/Umschlag #6: "<< /Policies << /PageSize 7 >> /PageSize [261 468] /ImagingBBox null >> setpagedevice"
+*PageSize Env9/Umschlag #9: "<< /Policies << /PageSize 7 >> /PageSize [279 639] /ImagingBBox null >> setpagedevice"
+*PageSize Env10/Umschlag #10: "<< /Policies << /PageSize 7 >> /PageSize [297 684] /ImagingBBox null >> setpagedevice"
+*PageSize EnvMonarch/Umschlag US-Monarch: "<< /Policies << /PageSize 7 >> /PageSize [279 540] /ImagingBBox null >> setpagedevice"
+*PageSize EnvDL/Umschlag DL: "<< /Policies << /PageSize 7 >> /PageSize [312 624] /ImagingBBox null >> setpagedevice"
+*PageSize EnvC5/Umschlag C5: "<< /Policies << /PageSize 7 >> /PageSize [459 649] /ImagingBBox null >> setpagedevice"
+*CloseUI: *PageSize
+
+*% Page Region Definitions for Frame Buffer
+*OpenUI *PageRegion: PickOne
+*OrderDependency: 40 AnySetup *PageRegion
+*DefaultPageRegion: A4
+*PageRegion A4/A4: "<< /Policies << /PageSize 7 >> /PageSize [595 842] /ImagingBBox null >> setpagedevice"
+*PageRegion A5/A5: "<< /Policies << /PageSize 7 >> /PageSize [421 595] /ImagingBBox null >> setpagedevice"
+*PageRegion A6/A6: "<< /Policies << /PageSize 7 >> /PageSize [297 421] /ImagingBBox null >> setpagedevice"
+*PageRegion B5/B5 (JIS): "<< /Policies << /PageSize 7 >> /PageSize [516 729] /ImagingBBox null >> setpagedevice"
+*PageRegion ISOB5/B5 (ISO): "<< /Policies << /PageSize 7 >> /PageSize [499 708] /ImagingBBox null >> setpagedevice"
+*PageRegion Letter/US-Letter: "<< /Policies << /PageSize 7 >> /PageSize [612 792] /ImagingBBox null >> setpagedevice"
+*PageRegion Legal/US-Legal: "<< /Policies << /PageSize 7 >> /PageSize [612 1008] /ImagingBBox null >> setpagedevice"
+*PageRegion Executive/US-Executive: "<< /Policies << /PageSize 7 >> /PageSize [522 756] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvPersonal/Umschlag #6: "<< /Policies << /PageSize 7 >> /PageSize [261 468] /ImagingBBox null >> setpagedevice"
+*PageRegion Env9/Umschlag #9: "<< /Policies << /PageSize 7 >> /PageSize [279 639] /ImagingBBox null >> setpagedevice"
+*PageRegion Env10/Umschlag #10: "<< /Policies << /PageSize 7 >> /PageSize [297 684] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvMonarch/Umschlag US-Monarch: "<< /Policies << /PageSize 7 >> /PageSize [279 540] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvDL/Umschlag DL: "<< /Policies << /PageSize 7 >> /PageSize [312 624] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvC5/Umschlag C5: "<< /Policies << /PageSize 7 >> /PageSize [459 649] /ImagingBBox null >> setpagedevice"
+*PageRegion OficioII/Oficio II: "<< /Policies << /PageSize 7 >> /PageSize [612 936] /ImagingBBox null >> setpagedevice"
+*PageRegion Folio/Folio (210 x 330mm): "<< /Policies << /PageSize 7 >> /PageSize [595 935] /ImagingBBox null >> setpagedevice"
+*PageRegion Statement/Statement: "<< /Policies << /PageSize 7 >> /PageSize [396 612] /ImagingBBox null >> setpagedevice"
+*PageRegion P16K/16K: "<< /Policies << /PageSize 7 >> /PageSize [558 774] /ImagingBBox null >> setpagedevice"
+*PageRegion OficioMX/216 x 340 mm: "<< /Policies << /PageSize 7 >> /PageSize [612 964] /ImagingBBox null >> setpagedevice"
+*CloseUI: *PageRegion
+
+*% Imageable Area Definitions
+*DefaultImageableArea: A4
+*ImageableArea A4/A4: "12 10 583 832"
+*ImageableArea A5/A5: "12 10 409 585"
+*ImageableArea A6/A6: "12 10 285 411"
+*ImageableArea B5/B5 (JIS): "21 10 495 719"
+*ImageableArea ISOB5/B5 (ISO): "12 12 487 696"
+*ImageableArea OficioII/Oficio II: "12 12 600 924"
+*ImageableArea Folio/Folio (210 x 330mm): "12 12 583 923"
+*ImageableArea Statement/Statement: "12 12 384 600"
+*ImageableArea P16K/16K: "12 12 547 763"
+*ImageableArea OficioMX/216 x 340 mm: "12 12 600 952"
+*ImageableArea Letter/US-Letter: "12 08 600 776"
+*ImageableArea Legal/US-Legal: "12 08 600 1000"
+*ImageableArea Executive/US-Executive: "12 08 510 748"
+*ImageableArea EnvPersonal/Umschlag #6: "12 08 249 460"
+*ImageableArea Env9/Umschlag #9: "12 08 267 631"
+*ImageableArea Env10/Umschlag #10: "12 08 285 676"
+*ImageableArea EnvMonarch/Umschlag US-Monarch: "12 08 267 532"
+*ImageableArea EnvDL/Umschlag DL: "12 10 300 614"
+*ImageableArea EnvC5/Umschlag C5: "12 10 447 639"
+*% Physical Dimensions of Media
+*DefaultPaperDimension: A4
+*PaperDimension A4/A4: "595 842"
+*PaperDimension A5/A5: "421 595"
+*PaperDimension A6/A6: "297 421"
+*PaperDimension B5/B5 (JIS): "516 729"
+*PaperDimension ISOB5/B5 (ISO): "499 708"
+*PaperDimension OficioII/Oficio II: "612 936"
+*PaperDimension Folio/Folio (210 x 330mm): "595 935"
+*PaperDimension Statement/Statement: "396 612"
+*PaperDimension P16K/16K: "558 774"
+*PaperDimension OficioMX/216 x 340 mm: "612 964"
+*PaperDimension Letter/US-Letter: "612 792"
+*PaperDimension Legal/US-Legal: "612 1008"
+*PaperDimension Executive/US-Executive: "522 756"
+*PaperDimension EnvPersonal/Umschlag #6: "261 468"
+*PaperDimension Env9/Umschlag #9: "279 639"
+*PaperDimension Env10/Umschlag #10: "297 684"
+*PaperDimension EnvMonarch/Umschlag US-Monarch: "279 540"
+*PaperDimension EnvDL/Umschlag DL: "312 624"
+*PaperDimension EnvC5/Umschlag C5: "459 649"
+
+*% Custom Page Size Definitions
+*% Smallest = A6, Largest = LEGAL
+
+*VariablePaperSize: True
+*LeadingEdge Short: ""
+*DefaultLeadingEdge: Short
+*HWMargins: 12 12 12 12
+*MaxMediaWidth: "612"
+*MaxMediaHeight: "1008"
+*NonUIOrderDependency: 40 AnySetup *CustomPageSize
+*CustomPageSize True: "
+  pop pop pop
+  << /PageSize [ 5 -2 roll ] /ImagingBBox null
+     /DeferredMediaSelection true
+  >> setpagedevice"
+*End
+*ParamCustomPageSize Width: 1 points 278 612
+*ParamCustomPageSize Height: 2 points 420 1008
+*ParamCustomPageSize WidthOffset: 3 points 0 0
+*ParamCustomPageSize HeightOffset: 4 points 0 0
+*ParamCustomPageSize Orientation: 5 int 1 1
+
+*OpenGroup: SpeedOptions/Modus reduzierter Geschwindigkeit
+
+*% Engine Speed Definitions
+*OpenUI *EngineSpeed/Modus reduzierter Geschwindigkeit: PickOne
+*OrderDependency: 40 AnySetup *EngineSpeed
+*DefaultEngineSpeed: Off
+*EngineSpeed On/Ein: ""
+*EngineSpeed Off/Aus: ""
+*CloseUI: *EngineSpeed
+
+*CloseGroup: SpeedOptions/Modus reduzierter Geschwindigkeit
+
+*OpenGroup: CaBrightness/Helligkeit
+
+*% Adjustment Definitions
+*OpenUI *CaBrightness/Helligkeit: PickOne
+*OrderDependency: 11 AnySetup *CaBrightness
+*DefaultCaBrightness: 0
+*CaBrightness -100/-100: ""
+*CaBrightness -90/-90: ""
+*CaBrightness -80/-80: ""
+*CaBrightness -70/-70: ""
+*CaBrightness -60/-60: ""
+*CaBrightness -50/-50: ""
+*CaBrightness -40/-40: ""
+*CaBrightness -30/-30: ""
+*CaBrightness -20/-20: ""
+*CaBrightness -10/-10: ""
+*CaBrightness 0/0: ""
+*CaBrightness 10/10: ""
+*CaBrightness 20/20: ""
+*CaBrightness 30/30: ""
+*CaBrightness 40/40: ""
+*CaBrightness 50/50: ""
+*CaBrightness 60/60: ""
+*CaBrightness 70/70: ""
+*CaBrightness 80/80: ""
+*CaBrightness 90/90: ""
+*CaBrightness 100/100: ""
+*CloseUI: *CaBrightness
+
+*CloseGroup: CaBrightness/Helligkeit
+
+*OpenGroup: CaContrast/Kontrast
+
+*% Adjustment Definitions
+*OpenUI *CaContrast/Kontrast: PickOne
+*OrderDependency: 12 AnySetup *CaContrast
+*DefaultCaContrast: 0
+*CaContrast -100/-100: ""
+*CaContrast -90/-90: ""
+*CaContrast -80/-80: ""
+*CaContrast -70/-70: ""
+*CaContrast -60/-60: ""
+*CaContrast -50/-50: ""
+*CaContrast -40/-40: ""
+*CaContrast -30/-30: ""
+*CaContrast -20/-20: ""
+*CaContrast -10/-10: ""
+*CaContrast 0/0: ""
+*CaContrast 10/10: ""
+*CaContrast 20/20: ""
+*CaContrast 30/30: ""
+*CaContrast 40/40: ""
+*CaContrast 50/50: ""
+*CaContrast 60/60: ""
+*CaContrast 70/70: ""
+*CaContrast 80/80: ""
+*CaContrast 90/90: ""
+*CaContrast 100/100: ""
+*CloseUI: *CaContrast
+
+*CloseGroup: CaContrast/Kontrast
+
+*OpenGroup: MediaOptions/Medientyp
+
+*% MediaType Definitions
+*OpenUI *MediaType/Medientyp: PickOne
+*OrderDependency: 95 AnySetup *MediaType
+*DefaultMediaType: PrnDef
+*MediaType PrnDef/Automatische Medienauswahl: "<</cupsMediaType 0 >> setpagedevice"
+*MediaType Plain/Normalpapier: "<</ManualFeed false /MediaType (Plain)/cupsMediaType 1 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Labels/Etiketten: "<</ManualFeed false /MediaType (Labels)/cupsMediaType 4 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Letterhead/Briefkopf: "<</ManualFeed false /MediaType (Letterhead)/cupsMediaType 9 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Bond/Feinpapier: "<</ManualFeed false /MediaType (Bond)/cupsMediaType 5 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Color/Mehrfarbig: "<</ManualFeed false /MediaType (Color)/cupsMediaType 10 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Preprinted/Vorgedruckt: "<</ManualFeed false /MediaType (Preprinted)/cupsMediaType 3 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Prepunched/Vorgelocht: "<</ManualFeed false /MediaType (Prepunched)/cupsMediaType 11 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Recycled/Recycling-Papier: "<</ManualFeed false /MediaType (Recycled)/cupsMediaType 6 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Cardstock/Karteikarte: "<</ManualFeed false /MediaType (Card Stock)/cupsMediaType 13 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Vellum/Pergament: "<</ManualFeed false /MediaType (Vellum)/cupsMediaType 7 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Envelope/Umschlag: "<</ManualFeed false /MediaType (Envelope)/cupsMediaType 12 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Rough/Grobpapier: "<</ManualFeed false /MediaType (Rough)/cupsMediaType 8 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Thick/Dick: "<</ManualFeed false /MediaType (Thick)/cupsMediaType 16 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Highqlty/Hohe Qualit<E4>t: "<</ManualFeed false /MediaType (Fine)/cupsMediaType 17 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User1/Benutzerdefinierter Typ 1: "<</ManualFeed false /MediaType (Custom Type1)/cupsMediaType 21 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User2/Benutzerdefinierter Typ 2: "<</ManualFeed false /MediaType (Custom Type2)/cupsMediaType 22 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User3/Benutzerdefinierter Typ 3: "<</ManualFeed false /MediaType (Custom Type3)/cupsMediaType 23 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User4/Benutzerdefinierter Typ 4: "<</ManualFeed false /MediaType (Custom Type4)/cupsMediaType 24 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User5/Benutzerdefinierter Typ 5: "<</ManualFeed false /MediaType (Custom Type5)/cupsMediaType 25 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User6/Benutzerdefinierter Typ 6: "<</ManualFeed false /MediaType (Custom Type6)/cupsMediaType 26 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User7/Benutzerdefinierter Typ 7: "<</ManualFeed false /MediaType (Custom Type7)/cupsMediaType 27 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User8/Benutzerdefinierter Typ 8: "<</ManualFeed false /MediaType (Custom Type8)/cupsMediaType 28 /DeferredMediaSelection true >> setpagedevice"
+*CloseUI: *MediaType
+
+*CloseGroup: MediaOptions/Medientyp
+
+*RequiresPageRegion All: True
+
+*% PPD Version Info 
+*OpenUI *KCVersion/PPD Version: PickOne
+*OrderDependency: 25 AnySetup *KCVersion
+*DefaultKCVersion: Default
+*KCVersion Default/1.1203 [03-23-2012]: ""
+*CloseUI: *KCVersion
+
+*% Font Information
+*DefaultFont: Courier
+*Font AvantGarde-Book: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-BookOblique: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-Demi: Standard "(001.007S)" Standard ROM
+*Font AvantGarde-DemiOblique: Standard "(001.007S)" Standard ROM
+*Font Bookman-Light: Standard "(001.004S)" Standard ROM
+*Font Bookman-LightItalic: Standard "(001.004S)" Standard ROM
+*Font Bookman-Demi: Standard "(001.004S)" Standard ROM
+*Font Bookman-DemiItalic: Standard "(001.004S)" Standard ROM
+*Font Courier: Standard "(002.004S)" Standard ROM
+*Font Courier-Oblique: Standard "(002.004S)" Standard ROM
+*Font Courier-Bold: Standard "(002.004S)" Standard ROM
+*Font Courier-BoldOblique: Standard "(002.004S)" Standard ROM
+*Font Helvetica: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Roman: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Italic: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Bold: Standard "(001.009S)" Standard ROM
+*Font NewCenturySchlbk-BoldItalic: Standard "(001.007S)" Standard ROM
+*Font Palatino-Roman: Standard "(001.005S)" Standard ROM
+*Font Palatino-Italic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Bold: Standard "(001.005S)" Standard ROM
+*Font Palatino-BoldItalic: Standard "(001.005S)" Standard ROM
+*Font Symbol: Special "(001.007S)" Special ROM
+*Font Times-Roman: Standard "(001.007S)" Standard ROM
+*Font Times-Italic: Standard "(001.007S)" Standard ROM
+*Font Times-Bold: Standard "(001.007S)" Standard ROM
+*Font Times-BoldItalic: Standard "(001.009S)" Standard ROM
+*Font ZapfChancery-MediumItalic: Standard "(001.007S)" Standard ROM
+*Font ZapfDingbats: Special "(001.004S)" Special ROM
+*Font Albertus-Medium: Standard "(001.008S)" Standard ROM
+*Font Albertus-ExtraBold: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Italic: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial: Standard "(001.008S)" Standard ROM
+*Font Arial-Italic: Standard "(001.008S)" Standard ROM
+*Font Arial-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGOmega: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Italic: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Bold: Standard "(001.008S)" Standard ROM
+*Font CGOmega-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGTimes: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Italic: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Bold: Standard "(001.008S)" Standard ROM
+*Font CGTimes-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Clarendon-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Coronet: Standard "(001.008S)" Standard ROM
+*Font CourierHP: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Italic: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Bold: Standard "(001.008S)" Standard ROM
+*Font CourierHP-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Garamond-Antiqua: Standard "(001.008S)" Standard ROM
+*Font Garamond-Halbfett: Standard "(001.008S)" Standard ROM
+*Font Garamond-Kursiv: Standard "(001.008S)" Standard ROM
+*Font Garamond-KursivHalbfett: Standard "(001.008S)" Standard ROM
+*Font LetterGothic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Italic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Bold: Standard "(001.008S)" Standard ROM
+*Font Marygold: Standard "(001.008S)" Standard ROM
+*Font SymbolMT: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Italic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Wingdings-Regular: Special "(001.008S)" Special ROM
+*?FontQuery: "
+  save
+  /str 80 string dup 0 (fonts/) putinterval def
+  {count 1 gt
+    { exch dup str 6 94 getinterval cvs
+      (/) print print (:) print
+      FontDirectory exch known
+      {(Yes)}{(No)} ifelse =
+    }{exit} ifelse
+  } bind loop (*)
+  = flush restore"
+*End
+*?FontList: "save FontDirectory { pop == } bind forall flush (*) = flush restore"
+*% Printer Messages
+*Message: "%%[ exitserver: permanent state may be changed ]%%"
+*Message: "%%[ Flushing: rest of job (to end-of-file) will be ignored ]%%"
+*Message: "\FontName\ not found, using Courier"
+
+*% Status (format: %%[ status: <one of these> ]%% )
+*Status: "warming up"/warming up
+*Status: "idle"/idle
+*Status: "busy"/busy
+*Status: "waiting"/waiting
+*Status: "printing"/printing
+*Status: "initializing"/initializing
+*Status: "printing test page"/printing test page
+*% Printer Error (format: %%[ PrinterError: <one of these> ]%% )
+*PrinterError: "paper entry misfeed"
+*PrinterError: "cover open"
+*PrinterError: "no paper tray"
+*PrinterError: "out of paper"
+*PrinterError: "toner low (halt)"
+*PrinterError: "warming up"
+*PrinterError: "other reason"
+*PrinterError: "video interface mode"
+*PrinterError: "offline"
+*PrinterError: "toner low (warning)"
+
+*% Input Sources (format: %%[ status: <stat>;source:<one of these> ]%% )
+*Source: "Serial"
+*Source: "Parallel"
+*Source: "LocalTalk"
+*Source: "Option"
+
+*%  End of PPD file for Kyocera FS-1220MFP (European German)

--- a/Kyocera_FS-1320MFPGDI.ppd
+++ b/Kyocera_FS-1320MFPGDI.ppd
@@ -1,0 +1,515 @@
+*PPD-Adobe: "4.3"
+*%=============================================================================
+*%
+*%  PPD file for Kyocera FS-1320MFP (European German)
+*%  Linux Version
+*%
+*% (C) 2012 KYOCERA Document Solutions Inc.
+*%
+*%  Permission is granted for redistribution of this file as long as this
+*%  copyright notice is intact and the contents of the file are not altered
+*%  in any way from their original form.
+*%
+*%  Permission is hereby granted, free of charge, to any person obtaining
+*%  a copy of this software and associated documentation files (the
+*%  "Software"), to deal in the Software without restriction, including
+*%  without limitation the rights to use, copy, modify, merge, publish,
+*%  distribute, sublicense, and/or sell copies of the Software, and to
+*%  permit persons to whom the Software is furnished to do so, subject to
+*%  the following conditions:
+*%
+*%  The above copyright notice and this permission notice shall be
+*%  included in all copies or substantial portions of the Software.
+*%
+*%  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+*%  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+*%  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+*%  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+*%  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+*%  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+*%  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*%
+*%  [this is the MIT open source license -- see www.opensource.org]
+*%
+*%=============================================================================
+
+*FileVersion: "1.1203"
+*FormatVersion: "4.3"
+*LanguageEncoding: ISOLatin1
+*LanguageVersion: German
+*Product: "(FS-1320MFP)"
+*PSVersion: "(3011.103) 1"
+*Manufacturer: "Kyocera"
+*ModelName: "Kyocera FS-1320MFP KPSL"
+*ShortNickName: "Kyocera FS-1320MFP (KPSL)"
+*NickName: "Kyocera FS-1320MFP (KPSL)"
+*PCFileName: "KC1320EG.PPD"
+
+*1284DeviceID: "MDL:FS-1320MFP;MFG:Kyocera"
+
+*cupsVersion: 1.2
+*cupsManualCopies: False
+*cupsModelNumber: 0
+*cupsSNMPSupplies: False
+
+*cupsFilter: "application/vnd.cups-raster 0 /usr/lib/cups/filter/rastertokpsl"
+
+*% Basic Device Capabilities
+*LandscapeOrientation: Plus90
+*AccurateScreensSupport: True
+*LanguageLevel: "3"
+*ColorDevice: False
+*ContoneOnly: False
+*DefaultColorSpace: Gray
+*TTRasterizer: Type42
+*?TTRasterizer: "
+  save
+  42 /FontType resourcestatus
+  { pop pop (Type42) }{ (None) } ifelse
+  = flush restore"
+*End
+
+*Throughput: "20"
+
+*% System Management
+*SuggestedJobTimeout: "0"
+*SuggestedManualFeedTimeout: "0"
+*SuggestedWaitTimeout: "120"
+*PrintPSErrors: True
+
+*Password: "0"
+
+*ExitServer: "
+  count 0 eq {true}
+  {dup statusdict /checkpassword get exec not} ifelse
+  {(WARNING : Cannot perform the exitserver command.) =
+    (Password supplied is not valid.) =
+    (Please contact the author of this software.) = flush quit} if
+  serverdict /exitserver get exec"
+*End
+
+*Reset: "
+  count 0 eq { true }
+  {dup statusdict /checkpassword get exec not} ifelse
+  {(WARNING : Cannot perform the exitserver command.) =
+    (Password supplied is not valid.) =
+    (Please contact the author of this software.) = flush quit} if
+  serverdict /exitserver get exec
+  systemdict /quit get exec
+  (WARNING : Printer Reset Failed.) = flush"
+*End
+
+*% Protocols
+*Protocols: TBCP
+
+*1284Modes Parallel: Compat Nibble ECP
+
+*% Virtual Memory
+*FreeVM: "32000000"
+
+*% Constraints
+*UIConstraints: *MediaType Labels *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Labels
+*UIConstraints: *MediaType Vellum *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Vellum
+*UIConstraints: *MediaType Envelope *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Envelope
+*UIConstraints: *MediaType Cardstock *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Cardstock
+
+*OpenGroup: GraphicsOptions/Grafiken
+
+*% Resolution 
+*OpenUI *Resolution/Aufl<F6>sung: PickOne
+*OrderDependency: 10 AnySetup *Resolution
+*DefaultResolution: 600dpi
+*Resolution 600dpi/600 dpi: "<< /HWResolution [600 600] /PreRenderingEnhance false >> setpagedevice"
+*CloseUI: *Resolution
+
+*% Color Model
+*OpenUI *ColorModel/Farbmodus: PickOne
+*OrderDependency: 10 AnySetup *ColorModel
+*DefaultColorModel: Gray
+*ColorModel Gray/Schwarz/Wei<DF>: "<< /ProcessColorModel /DeviceGray /cupsColorOrder 0/cupsColorSpace 3/cupsBitsPerColor 8/cupsCompression 1 >> setpagedevice"
+*CloseUI: *ColorModel
+
+*CloseGroup: GraphicsOptions/Grafiken
+
+*% Halftone Information 
+*DefaultHalftoneType: 1
+*ScreenFreq: "37.5"
+*ScreenAngle: "45.0"
+*ResScreenFreq 600dpi: "37.5"
+*ResScreenAngle 600dpi: "45.0"
+
+*DefaultScreenProc: Ellipse
+*ScreenProc Dot: "
+  {abs exch abs 2 copy add 1 gt
+  {1 sub dup mul exch 1 sub dup mul add 1 sub}
+  {dup mul exch dup mul add 1 exch sub} ifelse}"
+*End
+*ScreenProc Line: "{pop}"
+*ScreenProc Ellipse: "{dup 5 mul 8 div mul exch dup mul exch add sqrt 1 exch sub}"
+*DefaultTransfer: Null
+*Transfer Null: "{}"
+*Transfer Null.Inverse: "{1 exch sub}"
+
+*% Paper Handling 
+*% Page Size Definitions
+*OpenUI *PageSize: PickOne
+*OrderDependency: 40 AnySetup *PageSize
+*DefaultPageSize: A4
+*PageSize A4/A4: "<< /Policies << /PageSize 7 >> /PageSize [595 842] /ImagingBBox null >> setpagedevice"
+*PageSize A5/A5: "<< /Policies << /PageSize 7 >> /PageSize [421 595] /ImagingBBox null >> setpagedevice"
+*PageSize A6/A6: "<< /Policies << /PageSize 7 >> /PageSize [297 421] /ImagingBBox null >> setpagedevice"
+*PageSize B5/B5 (JIS): "<< /Policies << /PageSize 7 >> /PageSize [516 729] /ImagingBBox null >> setpagedevice"
+*PageSize ISOB5/B5 (ISO): "<< /Policies << /PageSize 7 >> /PageSize [499 708] /ImagingBBox null >> setpagedevice"
+*PageSize OficioII/Oficio II: "<< /Policies << /PageSize 7 >> /PageSize [612 936] /ImagingBBox null >> setpagedevice"
+*PageSize Folio/Folio (210 x 330mm): "<< /Policies << /PageSize 7 >> /PageSize [595 935] /ImagingBBox null >> setpagedevice"
+*PageSize Statement/Statement: "<< /Policies << /PageSize 7 >> /PageSize [396 612] /ImagingBBox null >> setpagedevice"
+*PageSize P16K/16K: "<< /Policies << /PageSize 7 >> /PageSize [558 774] /ImagingBBox null >> setpagedevice"
+*PageSize OficioMX/216 x 340 mm: "<< /Policies << /PageSize 7 >> /PageSize [612 964] /ImagingBBox null >> setpagedevice"
+*PageSize Letter/US-Letter: "<< /Policies << /PageSize 7 >> /PageSize [612 792] /ImagingBBox null >> setpagedevice"
+*PageSize Legal/US-Legal: "<< /Policies << /PageSize 7 >> /PageSize [612 1008] /ImagingBBox null >> setpagedevice"
+*PageSize Executive/US-Executive: "<< /Policies << /PageSize 7 >> /PageSize [522 756] /ImagingBBox null >> setpagedevice"
+*PageSize EnvPersonal/Umschlag #6: "<< /Policies << /PageSize 7 >> /PageSize [261 468] /ImagingBBox null >> setpagedevice"
+*PageSize Env9/Umschlag #9: "<< /Policies << /PageSize 7 >> /PageSize [279 639] /ImagingBBox null >> setpagedevice"
+*PageSize Env10/Umschlag #10: "<< /Policies << /PageSize 7 >> /PageSize [297 684] /ImagingBBox null >> setpagedevice"
+*PageSize EnvMonarch/Umschlag US-Monarch: "<< /Policies << /PageSize 7 >> /PageSize [279 540] /ImagingBBox null >> setpagedevice"
+*PageSize EnvDL/Umschlag DL: "<< /Policies << /PageSize 7 >> /PageSize [312 624] /ImagingBBox null >> setpagedevice"
+*PageSize EnvC5/Umschlag C5: "<< /Policies << /PageSize 7 >> /PageSize [459 649] /ImagingBBox null >> setpagedevice"
+*CloseUI: *PageSize
+
+*% Page Region Definitions for Frame Buffer
+*OpenUI *PageRegion: PickOne
+*OrderDependency: 40 AnySetup *PageRegion
+*DefaultPageRegion: A4
+*PageRegion A4/A4: "<< /Policies << /PageSize 7 >> /PageSize [595 842] /ImagingBBox null >> setpagedevice"
+*PageRegion A5/A5: "<< /Policies << /PageSize 7 >> /PageSize [421 595] /ImagingBBox null >> setpagedevice"
+*PageRegion A6/A6: "<< /Policies << /PageSize 7 >> /PageSize [297 421] /ImagingBBox null >> setpagedevice"
+*PageRegion B5/B5 (JIS): "<< /Policies << /PageSize 7 >> /PageSize [516 729] /ImagingBBox null >> setpagedevice"
+*PageRegion ISOB5/B5 (ISO): "<< /Policies << /PageSize 7 >> /PageSize [499 708] /ImagingBBox null >> setpagedevice"
+*PageRegion Letter/US-Letter: "<< /Policies << /PageSize 7 >> /PageSize [612 792] /ImagingBBox null >> setpagedevice"
+*PageRegion Legal/US-Legal: "<< /Policies << /PageSize 7 >> /PageSize [612 1008] /ImagingBBox null >> setpagedevice"
+*PageRegion Executive/US-Executive: "<< /Policies << /PageSize 7 >> /PageSize [522 756] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvPersonal/Umschlag #6: "<< /Policies << /PageSize 7 >> /PageSize [261 468] /ImagingBBox null >> setpagedevice"
+*PageRegion Env9/Umschlag #9: "<< /Policies << /PageSize 7 >> /PageSize [279 639] /ImagingBBox null >> setpagedevice"
+*PageRegion Env10/Umschlag #10: "<< /Policies << /PageSize 7 >> /PageSize [297 684] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvMonarch/Umschlag US-Monarch: "<< /Policies << /PageSize 7 >> /PageSize [279 540] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvDL/Umschlag DL: "<< /Policies << /PageSize 7 >> /PageSize [312 624] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvC5/Umschlag C5: "<< /Policies << /PageSize 7 >> /PageSize [459 649] /ImagingBBox null >> setpagedevice"
+*PageRegion OficioII/Oficio II: "<< /Policies << /PageSize 7 >> /PageSize [612 936] /ImagingBBox null >> setpagedevice"
+*PageRegion Folio/Folio (210 x 330mm): "<< /Policies << /PageSize 7 >> /PageSize [595 935] /ImagingBBox null >> setpagedevice"
+*PageRegion Statement/Statement: "<< /Policies << /PageSize 7 >> /PageSize [396 612] /ImagingBBox null >> setpagedevice"
+*PageRegion P16K/16K: "<< /Policies << /PageSize 7 >> /PageSize [558 774] /ImagingBBox null >> setpagedevice"
+*PageRegion OficioMX/216 x 340 mm: "<< /Policies << /PageSize 7 >> /PageSize [612 964] /ImagingBBox null >> setpagedevice"
+*CloseUI: *PageRegion
+
+*% Imageable Area Definitions
+*DefaultImageableArea: A4
+*ImageableArea A4/A4: "12 10 583 832"
+*ImageableArea A5/A5: "12 10 409 585"
+*ImageableArea A6/A6: "12 10 285 411"
+*ImageableArea B5/B5 (JIS): "21 10 495 719"
+*ImageableArea ISOB5/B5 (ISO): "12 12 487 696"
+*ImageableArea OficioII/Oficio II: "12 12 600 924"
+*ImageableArea Folio/Folio (210 x 330mm): "12 12 583 923"
+*ImageableArea Statement/Statement: "12 12 384 600"
+*ImageableArea P16K/16K: "12 12 547 763"
+*ImageableArea OficioMX/216 x 340 mm: "12 12 600 952"
+*ImageableArea Letter/US-Letter: "12 08 600 776"
+*ImageableArea Legal/US-Legal: "12 08 600 1000"
+*ImageableArea Executive/US-Executive: "12 08 510 748"
+*ImageableArea EnvPersonal/Umschlag #6: "12 08 249 460"
+*ImageableArea Env9/Umschlag #9: "12 08 267 631"
+*ImageableArea Env10/Umschlag #10: "12 08 285 676"
+*ImageableArea EnvMonarch/Umschlag US-Monarch: "12 08 267 532"
+*ImageableArea EnvDL/Umschlag DL: "12 10 300 614"
+*ImageableArea EnvC5/Umschlag C5: "12 10 447 639"
+*% Physical Dimensions of Media
+*DefaultPaperDimension: A4
+*PaperDimension A4/A4: "595 842"
+*PaperDimension A5/A5: "421 595"
+*PaperDimension A6/A6: "297 421"
+*PaperDimension B5/B5 (JIS): "516 729"
+*PaperDimension ISOB5/B5 (ISO): "499 708"
+*PaperDimension OficioII/Oficio II: "612 936"
+*PaperDimension Folio/Folio (210 x 330mm): "595 935"
+*PaperDimension Statement/Statement: "396 612"
+*PaperDimension P16K/16K: "558 774"
+*PaperDimension OficioMX/216 x 340 mm: "612 964"
+*PaperDimension Letter/US-Letter: "612 792"
+*PaperDimension Legal/US-Legal: "612 1008"
+*PaperDimension Executive/US-Executive: "522 756"
+*PaperDimension EnvPersonal/Umschlag #6: "261 468"
+*PaperDimension Env9/Umschlag #9: "279 639"
+*PaperDimension Env10/Umschlag #10: "297 684"
+*PaperDimension EnvMonarch/Umschlag US-Monarch: "279 540"
+*PaperDimension EnvDL/Umschlag DL: "312 624"
+*PaperDimension EnvC5/Umschlag C5: "459 649"
+
+*% Custom Page Size Definitions
+*% Smallest = A6, Largest = LEGAL
+
+*VariablePaperSize: True
+*LeadingEdge Short: ""
+*DefaultLeadingEdge: Short
+*HWMargins: 12 12 12 12
+*MaxMediaWidth: "612"
+*MaxMediaHeight: "1008"
+*NonUIOrderDependency: 40 AnySetup *CustomPageSize
+*CustomPageSize True: "
+  pop pop pop
+  << /PageSize [ 5 -2 roll ] /ImagingBBox null
+     /DeferredMediaSelection true
+  >> setpagedevice"
+*End
+*ParamCustomPageSize Width: 1 points 278 612
+*ParamCustomPageSize Height: 2 points 420 1008
+*ParamCustomPageSize WidthOffset: 3 points 0 0
+*ParamCustomPageSize HeightOffset: 4 points 0 0
+*ParamCustomPageSize Orientation: 5 int 1 1
+
+*OpenGroup: SpeedOptions/Modus reduzierter Geschwindigkeit
+
+*% Engine Speed Definitions
+*OpenUI *EngineSpeed/Modus reduzierter Geschwindigkeit: PickOne
+*OrderDependency: 40 AnySetup *EngineSpeed
+*DefaultEngineSpeed: Off
+*EngineSpeed On/Ein: ""
+*EngineSpeed Off/Aus: ""
+*CloseUI: *EngineSpeed
+
+*CloseGroup: SpeedOptions/Modus reduzierter Geschwindigkeit
+
+*OpenGroup: CaBrightness/Helligkeit
+
+*% Adjustment Definitions
+*OpenUI *CaBrightness/Helligkeit: PickOne
+*OrderDependency: 11 AnySetup *CaBrightness
+*DefaultCaBrightness: 0
+*CaBrightness -100/-100: ""
+*CaBrightness -90/-90: ""
+*CaBrightness -80/-80: ""
+*CaBrightness -70/-70: ""
+*CaBrightness -60/-60: ""
+*CaBrightness -50/-50: ""
+*CaBrightness -40/-40: ""
+*CaBrightness -30/-30: ""
+*CaBrightness -20/-20: ""
+*CaBrightness -10/-10: ""
+*CaBrightness 0/0: ""
+*CaBrightness 10/10: ""
+*CaBrightness 20/20: ""
+*CaBrightness 30/30: ""
+*CaBrightness 40/40: ""
+*CaBrightness 50/50: ""
+*CaBrightness 60/60: ""
+*CaBrightness 70/70: ""
+*CaBrightness 80/80: ""
+*CaBrightness 90/90: ""
+*CaBrightness 100/100: ""
+*CloseUI: *CaBrightness
+
+*CloseGroup: CaBrightness/Helligkeit
+
+*OpenGroup: CaContrast/Kontrast
+
+*% Adjustment Definitions
+*OpenUI *CaContrast/Kontrast: PickOne
+*OrderDependency: 12 AnySetup *CaContrast
+*DefaultCaContrast: 0
+*CaContrast -100/-100: ""
+*CaContrast -90/-90: ""
+*CaContrast -80/-80: ""
+*CaContrast -70/-70: ""
+*CaContrast -60/-60: ""
+*CaContrast -50/-50: ""
+*CaContrast -40/-40: ""
+*CaContrast -30/-30: ""
+*CaContrast -20/-20: ""
+*CaContrast -10/-10: ""
+*CaContrast 0/0: ""
+*CaContrast 10/10: ""
+*CaContrast 20/20: ""
+*CaContrast 30/30: ""
+*CaContrast 40/40: ""
+*CaContrast 50/50: ""
+*CaContrast 60/60: ""
+*CaContrast 70/70: ""
+*CaContrast 80/80: ""
+*CaContrast 90/90: ""
+*CaContrast 100/100: ""
+*CloseUI: *CaContrast
+
+*CloseGroup: CaContrast/Kontrast
+
+*OpenGroup: MediaOptions/Medientyp
+
+*% MediaType Definitions
+*OpenUI *MediaType/Medientyp: PickOne
+*OrderDependency: 95 AnySetup *MediaType
+*DefaultMediaType: PrnDef
+*MediaType PrnDef/Automatische Medienauswahl: "<</cupsMediaType 0 >> setpagedevice"
+*MediaType Plain/Normalpapier: "<</ManualFeed false /MediaType (Plain)/cupsMediaType 1 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Labels/Etiketten: "<</ManualFeed false /MediaType (Labels)/cupsMediaType 4 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Letterhead/Briefkopf: "<</ManualFeed false /MediaType (Letterhead)/cupsMediaType 9 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Bond/Feinpapier: "<</ManualFeed false /MediaType (Bond)/cupsMediaType 5 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Color/Mehrfarbig: "<</ManualFeed false /MediaType (Color)/cupsMediaType 10 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Preprinted/Vorgedruckt: "<</ManualFeed false /MediaType (Preprinted)/cupsMediaType 3 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Prepunched/Vorgelocht: "<</ManualFeed false /MediaType (Prepunched)/cupsMediaType 11 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Recycled/Recycling-Papier: "<</ManualFeed false /MediaType (Recycled)/cupsMediaType 6 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Cardstock/Karteikarte: "<</ManualFeed false /MediaType (Card Stock)/cupsMediaType 13 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Vellum/Pergament: "<</ManualFeed false /MediaType (Vellum)/cupsMediaType 7 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Envelope/Umschlag: "<</ManualFeed false /MediaType (Envelope)/cupsMediaType 12 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Rough/Grobpapier: "<</ManualFeed false /MediaType (Rough)/cupsMediaType 8 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Thick/Dick: "<</ManualFeed false /MediaType (Thick)/cupsMediaType 16 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Highqlty/Hohe Qualit<E4>t: "<</ManualFeed false /MediaType (Fine)/cupsMediaType 17 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User1/Benutzerdefinierter Typ 1: "<</ManualFeed false /MediaType (Custom Type1)/cupsMediaType 21 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User2/Benutzerdefinierter Typ 2: "<</ManualFeed false /MediaType (Custom Type2)/cupsMediaType 22 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User3/Benutzerdefinierter Typ 3: "<</ManualFeed false /MediaType (Custom Type3)/cupsMediaType 23 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User4/Benutzerdefinierter Typ 4: "<</ManualFeed false /MediaType (Custom Type4)/cupsMediaType 24 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User5/Benutzerdefinierter Typ 5: "<</ManualFeed false /MediaType (Custom Type5)/cupsMediaType 25 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User6/Benutzerdefinierter Typ 6: "<</ManualFeed false /MediaType (Custom Type6)/cupsMediaType 26 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User7/Benutzerdefinierter Typ 7: "<</ManualFeed false /MediaType (Custom Type7)/cupsMediaType 27 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User8/Benutzerdefinierter Typ 8: "<</ManualFeed false /MediaType (Custom Type8)/cupsMediaType 28 /DeferredMediaSelection true >> setpagedevice"
+*CloseUI: *MediaType
+
+*CloseGroup: MediaOptions/Medientyp
+
+*RequiresPageRegion All: True
+
+*% PPD Version Info 
+*OpenUI *KCVersion/PPD Version: PickOne
+*OrderDependency: 25 AnySetup *KCVersion
+*DefaultKCVersion: Default
+*KCVersion Default/1.1203 [03-23-2012]: ""
+*CloseUI: *KCVersion
+
+*% Font Information
+*DefaultFont: Courier
+*Font AvantGarde-Book: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-BookOblique: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-Demi: Standard "(001.007S)" Standard ROM
+*Font AvantGarde-DemiOblique: Standard "(001.007S)" Standard ROM
+*Font Bookman-Light: Standard "(001.004S)" Standard ROM
+*Font Bookman-LightItalic: Standard "(001.004S)" Standard ROM
+*Font Bookman-Demi: Standard "(001.004S)" Standard ROM
+*Font Bookman-DemiItalic: Standard "(001.004S)" Standard ROM
+*Font Courier: Standard "(002.004S)" Standard ROM
+*Font Courier-Oblique: Standard "(002.004S)" Standard ROM
+*Font Courier-Bold: Standard "(002.004S)" Standard ROM
+*Font Courier-BoldOblique: Standard "(002.004S)" Standard ROM
+*Font Helvetica: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Roman: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Italic: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Bold: Standard "(001.009S)" Standard ROM
+*Font NewCenturySchlbk-BoldItalic: Standard "(001.007S)" Standard ROM
+*Font Palatino-Roman: Standard "(001.005S)" Standard ROM
+*Font Palatino-Italic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Bold: Standard "(001.005S)" Standard ROM
+*Font Palatino-BoldItalic: Standard "(001.005S)" Standard ROM
+*Font Symbol: Special "(001.007S)" Special ROM
+*Font Times-Roman: Standard "(001.007S)" Standard ROM
+*Font Times-Italic: Standard "(001.007S)" Standard ROM
+*Font Times-Bold: Standard "(001.007S)" Standard ROM
+*Font Times-BoldItalic: Standard "(001.009S)" Standard ROM
+*Font ZapfChancery-MediumItalic: Standard "(001.007S)" Standard ROM
+*Font ZapfDingbats: Special "(001.004S)" Special ROM
+*Font Albertus-Medium: Standard "(001.008S)" Standard ROM
+*Font Albertus-ExtraBold: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Italic: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial: Standard "(001.008S)" Standard ROM
+*Font Arial-Italic: Standard "(001.008S)" Standard ROM
+*Font Arial-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGOmega: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Italic: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Bold: Standard "(001.008S)" Standard ROM
+*Font CGOmega-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGTimes: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Italic: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Bold: Standard "(001.008S)" Standard ROM
+*Font CGTimes-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Clarendon-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Coronet: Standard "(001.008S)" Standard ROM
+*Font CourierHP: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Italic: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Bold: Standard "(001.008S)" Standard ROM
+*Font CourierHP-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Garamond-Antiqua: Standard "(001.008S)" Standard ROM
+*Font Garamond-Halbfett: Standard "(001.008S)" Standard ROM
+*Font Garamond-Kursiv: Standard "(001.008S)" Standard ROM
+*Font Garamond-KursivHalbfett: Standard "(001.008S)" Standard ROM
+*Font LetterGothic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Italic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Bold: Standard "(001.008S)" Standard ROM
+*Font Marygold: Standard "(001.008S)" Standard ROM
+*Font SymbolMT: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Italic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Wingdings-Regular: Special "(001.008S)" Special ROM
+*?FontQuery: "
+  save
+  /str 80 string dup 0 (fonts/) putinterval def
+  {count 1 gt
+    { exch dup str 6 94 getinterval cvs
+      (/) print print (:) print
+      FontDirectory exch known
+      {(Yes)}{(No)} ifelse =
+    }{exit} ifelse
+  } bind loop (*)
+  = flush restore"
+*End
+*?FontList: "save FontDirectory { pop == } bind forall flush (*) = flush restore"
+*% Printer Messages
+*Message: "%%[ exitserver: permanent state may be changed ]%%"
+*Message: "%%[ Flushing: rest of job (to end-of-file) will be ignored ]%%"
+*Message: "\FontName\ not found, using Courier"
+
+*% Status (format: %%[ status: <one of these> ]%% )
+*Status: "warming up"/warming up
+*Status: "idle"/idle
+*Status: "busy"/busy
+*Status: "waiting"/waiting
+*Status: "printing"/printing
+*Status: "initializing"/initializing
+*Status: "printing test page"/printing test page
+*% Printer Error (format: %%[ PrinterError: <one of these> ]%% )
+*PrinterError: "paper entry misfeed"
+*PrinterError: "cover open"
+*PrinterError: "no paper tray"
+*PrinterError: "out of paper"
+*PrinterError: "toner low (halt)"
+*PrinterError: "warming up"
+*PrinterError: "other reason"
+*PrinterError: "video interface mode"
+*PrinterError: "offline"
+*PrinterError: "toner low (warning)"
+
+*% Input Sources (format: %%[ status: <stat>;source:<one of these> ]%% )
+*Source: "Serial"
+*Source: "Parallel"
+*Source: "LocalTalk"
+*Source: "Option"
+
+*%  End of PPD file for Kyocera FS-1320MFP (European German)

--- a/Kyocera_FS-1325MFPGDI.ppd
+++ b/Kyocera_FS-1325MFPGDI.ppd
@@ -1,0 +1,624 @@
+*PPD-Adobe: "4.3"
+*%=============================================================================
+*%
+*%  PPD file for Kyocera FS-1325MFP (European German)
+*%  Linux Version
+*%
+*% (C) 2012 KYOCERA Document Solutions Inc.
+*%
+*%  Permission is granted for redistribution of this file as long as this
+*%  copyright notice is intact and the contents of the file are not altered
+*%  in any way from their original form.
+*%
+*%  Permission is hereby granted, free of charge, to any person obtaining
+*%  a copy of this software and associated documentation files (the
+*%  "Software"), to deal in the Software without restriction, including
+*%  without limitation the rights to use, copy, modify, merge, publish,
+*%  distribute, sublicense, and/or sell copies of the Software, and to
+*%  permit persons to whom the Software is furnished to do so, subject to
+*%  the following conditions:
+*%
+*%  The above copyright notice and this permission notice shall be
+*%  included in all copies or substantial portions of the Software.
+*%
+*%  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+*%  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+*%  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+*%  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+*%  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+*%  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+*%  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*%
+*%  [this is the MIT open source license -- see www.opensource.org]
+*%
+*%=============================================================================
+
+*FileVersion: "1.1203"
+*FormatVersion: "4.3"
+*LanguageEncoding: ISOLatin1
+*LanguageVersion: German
+*Product: "(FS-1325MFP)"
+*PSVersion: "(3011.103) 1"
+*Manufacturer: "Kyocera"
+*ModelName: "Kyocera FS-1325MFP KPSL"
+*ShortNickName: "Kyocera FS-1325MFP (KPSL)"
+*NickName: "Kyocera FS-1325MFP (KPSL)"
+*PCFileName: "KC1325EG.PPD"
+
+*1284DeviceID: "MDL:FS-1325MFP;MFG:Kyocera"
+
+*cupsVersion: 1.2
+*cupsManualCopies: False
+*cupsModelNumber: 0
+*cupsSNMPSupplies: False
+
+*cupsFilter: "application/vnd.cups-raster 0 /usr/lib/cups/filter/rastertokpsl"
+
+*% Basic Device Capabilities
+*LandscapeOrientation: Plus90
+*AccurateScreensSupport: True
+*LanguageLevel: "3"
+*ColorDevice: False
+*ContoneOnly: False
+*DefaultColorSpace: Gray
+*TTRasterizer: Type42
+*?TTRasterizer: "
+  save
+  42 /FontType resourcestatus
+  { pop pop (Type42) }{ (None) } ifelse
+  = flush restore"
+*End
+
+*Throughput: "25"
+
+*% System Management
+*SuggestedJobTimeout: "0"
+*SuggestedManualFeedTimeout: "0"
+*SuggestedWaitTimeout: "120"
+*PrintPSErrors: True
+
+*Password: "0"
+
+*ExitServer: "
+  count 0 eq {true}
+  {dup statusdict /checkpassword get exec not} ifelse
+  {(WARNING : Cannot perform the exitserver command.) =
+    (Password supplied is not valid.) =
+    (Please contact the author of this software.) = flush quit} if
+  serverdict /exitserver get exec"
+*End
+
+*Reset: "
+  count 0 eq { true }
+  {dup statusdict /checkpassword get exec not} ifelse
+  {(WARNING : Cannot perform the exitserver command.) =
+    (Password supplied is not valid.) =
+    (Please contact the author of this software.) = flush quit} if
+  serverdict /exitserver get exec
+  systemdict /quit get exec
+  (WARNING : Printer Reset Failed.) = flush"
+*End
+
+*% Protocols
+*Protocols: TBCP
+
+*1284Modes Parallel: Compat Nibble ECP
+
+*% Virtual Memory
+*FreeVM: "32000000"
+
+*% Constraints
+*UIConstraints: *Duplex *PageSize Statement
+*UIConstraints: *PageSize Statement *Duplex DuplexTumble
+*UIConstraints: *PageSize Statement *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion Statement
+*UIConstraints: *PageRegion Statement *Duplex DuplexTumble
+*UIConstraints: *PageRegion Statement *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageSize A5
+*UIConstraints: *PageSize A5 *Duplex DuplexTumble
+*UIConstraints: *PageSize A5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion A5
+*UIConstraints: *PageRegion A5 *Duplex DuplexTumble
+*UIConstraints: *PageRegion A5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageSize ISOB5
+*UIConstraints: *PageSize ISOB5 *Duplex DuplexTumble
+*UIConstraints: *PageSize ISOB5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion ISOB5
+*UIConstraints: *PageRegion ISOB5 *Duplex DuplexTumble
+*UIConstraints: *PageRegion ISOB5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageSize EnvC5
+*UIConstraints: *PageSize EnvC5 *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvC5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion EnvC5
+*UIConstraints: *PageRegion EnvC5 *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvC5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageSize B5
+*UIConstraints: *PageSize B5 *Duplex DuplexTumble
+*UIConstraints: *PageSize B5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion B5
+*UIConstraints: *PageRegion B5 *Duplex DuplexTumble
+*UIConstraints: *PageRegion B5 *Duplex  DuplexNoTumble
+*UIConstraints: *Duplex *MediaType Labels
+*UIConstraints: *MediaType Labels *Duplex DuplexTumble
+*UIConstraints: *MediaType Labels *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *MediaType Vellum
+*UIConstraints: *MediaType Vellum *Duplex DuplexTumble
+*UIConstraints: *MediaType Vellum *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *MediaType Envelope
+*UIConstraints: *MediaType Envelope *Duplex DuplexTumble
+*UIConstraints: *MediaType Envelope *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *MediaType Cardstock
+*UIConstraints: *MediaType Cardstock *Duplex DuplexTumble
+*UIConstraints: *MediaType Cardstock *Duplex DuplexNoTumble
+*UIConstraints: *MediaType Labels *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Labels
+*UIConstraints: *MediaType Vellum *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Vellum
+*UIConstraints: *MediaType Envelope *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Envelope
+*UIConstraints: *MediaType Cardstock *InputSlot Internal
+*UIConstraints: *InputSlot Internal *MediaType Cardstock
+*NonUIConstraints: *Duplex *CustomPageSize True
+*NonUIConstraints: *CustomPageSize True *Duplex
+*UIConstraints: *Duplex *PageSize A6
+*UIConstraints: *PageSize A6 *Duplex DuplexTumble
+*UIConstraints: *PageSize A6 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion A6
+*UIConstraints: *PageRegion A6 *Duplex DuplexTumble
+*UIConstraints: *PageRegion A6 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageSize EnvPersonal
+*UIConstraints: *PageSize EnvPersonal *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvPersonal *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion EnvPersonal
+*UIConstraints: *PageRegion EnvPersonal *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvPersonal *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageSize Env9
+*UIConstraints: *PageSize Env9 *Duplex DuplexTumble
+*UIConstraints: *PageSize Env9 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion Env9
+*UIConstraints: *PageRegion Env9 *Duplex DuplexTumble
+*UIConstraints: *PageRegion Env9 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageSize Env10
+*UIConstraints: *PageSize Env10 *Duplex DuplexTumble
+*UIConstraints: *PageSize Env10 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion Env10
+*UIConstraints: *PageRegion Env10 *Duplex DuplexTumble
+*UIConstraints: *PageRegion Env10 *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageSize EnvMonarch
+*UIConstraints: *PageSize EnvMonarch *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvMonarch *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion EnvMonarch
+*UIConstraints: *PageRegion EnvMonarch *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvMonarch *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageSize EnvDL
+*UIConstraints: *PageSize EnvDL *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvDL *Duplex DuplexNoTumble
+*UIConstraints: *Duplex *PageRegion EnvDL
+*UIConstraints: *PageRegion EnvDL *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvDL *Duplex DuplexNoTumble
+
+*OpenGroup: GraphicsOptions/Grafiken
+
+*% Resolution 
+*OpenUI *Resolution/Aufl<F6>sung: PickOne
+*OrderDependency: 10 AnySetup *Resolution
+*DefaultResolution: 600dpi
+*Resolution 600dpi/600 dpi: "<< /HWResolution [600 600] /PreRenderingEnhance false >> setpagedevice"
+*CloseUI: *Resolution
+
+*% Color Model
+*OpenUI *ColorModel/Farbmodus: PickOne
+*OrderDependency: 10 AnySetup *ColorModel
+*DefaultColorModel: Gray
+*ColorModel Gray/Schwarz/Wei<DF>: "<< /ProcessColorModel /DeviceGray /cupsColorOrder 0/cupsColorSpace 3/cupsBitsPerColor 8/cupsCompression 1 >> setpagedevice"
+*CloseUI: *ColorModel
+
+*CloseGroup: GraphicsOptions/Grafiken
+
+*% Halftone Information 
+*DefaultHalftoneType: 1
+*ScreenFreq: "37.5"
+*ScreenAngle: "45.0"
+*ResScreenFreq 600dpi: "37.5"
+*ResScreenAngle 600dpi: "45.0"
+
+*DefaultScreenProc: Ellipse
+*ScreenProc Dot: "
+  {abs exch abs 2 copy add 1 gt
+  {1 sub dup mul exch 1 sub dup mul add 1 sub}
+  {dup mul exch dup mul add 1 exch sub} ifelse}"
+*End
+*ScreenProc Line: "{pop}"
+*ScreenProc Ellipse: "{dup 5 mul 8 div mul exch dup mul exch add sqrt 1 exch sub}"
+*DefaultTransfer: Null
+*Transfer Null: "{}"
+*Transfer Null.Inverse: "{1 exch sub}"
+
+*% Paper Handling 
+*% Page Size Definitions
+*OpenUI *PageSize: PickOne
+*OrderDependency: 40 AnySetup *PageSize
+*DefaultPageSize: A4
+*PageSize A4/A4: "<< /Policies << /PageSize 7 >> /PageSize [595 842] /ImagingBBox null >> setpagedevice"
+*PageSize A5/A5: "<< /Policies << /PageSize 7 >> /PageSize [421 595] /ImagingBBox null >> setpagedevice"
+*PageSize A6/A6: "<< /Policies << /PageSize 7 >> /PageSize [297 421] /ImagingBBox null >> setpagedevice"
+*PageSize B5/B5 (JIS): "<< /Policies << /PageSize 7 >> /PageSize [516 729] /ImagingBBox null >> setpagedevice"
+*PageSize ISOB5/B5 (ISO): "<< /Policies << /PageSize 7 >> /PageSize [499 708] /ImagingBBox null >> setpagedevice"
+*PageSize OficioII/Oficio II: "<< /Policies << /PageSize 7 >> /PageSize [612 936] /ImagingBBox null >> setpagedevice"
+*PageSize Folio/Folio (210 x 330mm): "<< /Policies << /PageSize 7 >> /PageSize [595 935] /ImagingBBox null >> setpagedevice"
+*PageSize Statement/Statement: "<< /Policies << /PageSize 7 >> /PageSize [396 612] /ImagingBBox null >> setpagedevice"
+*PageSize P16K/16K: "<< /Policies << /PageSize 7 >> /PageSize [558 774] /ImagingBBox null >> setpagedevice"
+*PageSize OficioMX/216 x 340 mm: "<< /Policies << /PageSize 7 >> /PageSize [612 964] /ImagingBBox null >> setpagedevice"
+*PageSize Letter/US-Letter: "<< /Policies << /PageSize 7 >> /PageSize [612 792] /ImagingBBox null >> setpagedevice"
+*PageSize Legal/US-Legal: "<< /Policies << /PageSize 7 >> /PageSize [612 1008] /ImagingBBox null >> setpagedevice"
+*PageSize Executive/US-Executive: "<< /Policies << /PageSize 7 >> /PageSize [522 756] /ImagingBBox null >> setpagedevice"
+*PageSize EnvPersonal/Umschlag #6: "<< /Policies << /PageSize 7 >> /PageSize [261 468] /ImagingBBox null >> setpagedevice"
+*PageSize Env9/Umschlag #9: "<< /Policies << /PageSize 7 >> /PageSize [279 639] /ImagingBBox null >> setpagedevice"
+*PageSize Env10/Umschlag #10: "<< /Policies << /PageSize 7 >> /PageSize [297 684] /ImagingBBox null >> setpagedevice"
+*PageSize EnvMonarch/Umschlag US-Monarch: "<< /Policies << /PageSize 7 >> /PageSize [279 540] /ImagingBBox null >> setpagedevice"
+*PageSize EnvDL/Umschlag DL: "<< /Policies << /PageSize 7 >> /PageSize [312 624] /ImagingBBox null >> setpagedevice"
+*PageSize EnvC5/Umschlag C5: "<< /Policies << /PageSize 7 >> /PageSize [459 649] /ImagingBBox null >> setpagedevice"
+*CloseUI: *PageSize
+
+*% Page Region Definitions for Frame Buffer
+*OpenUI *PageRegion: PickOne
+*OrderDependency: 40 AnySetup *PageRegion
+*DefaultPageRegion: A4
+*PageRegion A4/A4: "<< /Policies << /PageSize 7 >> /PageSize [595 842] /ImagingBBox null >> setpagedevice"
+*PageRegion A5/A5: "<< /Policies << /PageSize 7 >> /PageSize [421 595] /ImagingBBox null >> setpagedevice"
+*PageRegion A6/A6: "<< /Policies << /PageSize 7 >> /PageSize [297 421] /ImagingBBox null >> setpagedevice"
+*PageRegion B5/B5 (JIS): "<< /Policies << /PageSize 7 >> /PageSize [516 729] /ImagingBBox null >> setpagedevice"
+*PageRegion ISOB5/B5 (ISO): "<< /Policies << /PageSize 7 >> /PageSize [499 708] /ImagingBBox null >> setpagedevice"
+*PageRegion Letter/US-Letter: "<< /Policies << /PageSize 7 >> /PageSize [612 792] /ImagingBBox null >> setpagedevice"
+*PageRegion Legal/US-Legal: "<< /Policies << /PageSize 7 >> /PageSize [612 1008] /ImagingBBox null >> setpagedevice"
+*PageRegion Executive/US-Executive: "<< /Policies << /PageSize 7 >> /PageSize [522 756] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvPersonal/Umschlag #6: "<< /Policies << /PageSize 7 >> /PageSize [261 468] /ImagingBBox null >> setpagedevice"
+*PageRegion Env9/Umschlag #9: "<< /Policies << /PageSize 7 >> /PageSize [279 639] /ImagingBBox null >> setpagedevice"
+*PageRegion Env10/Umschlag #10: "<< /Policies << /PageSize 7 >> /PageSize [297 684] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvMonarch/Umschlag US-Monarch: "<< /Policies << /PageSize 7 >> /PageSize [279 540] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvDL/Umschlag DL: "<< /Policies << /PageSize 7 >> /PageSize [312 624] /ImagingBBox null >> setpagedevice"
+*PageRegion EnvC5/Umschlag C5: "<< /Policies << /PageSize 7 >> /PageSize [459 649] /ImagingBBox null >> setpagedevice"
+*PageRegion OficioII/Oficio II: "<< /Policies << /PageSize 7 >> /PageSize [612 936] /ImagingBBox null >> setpagedevice"
+*PageRegion Folio/Folio (210 x 330mm): "<< /Policies << /PageSize 7 >> /PageSize [595 935] /ImagingBBox null >> setpagedevice"
+*PageRegion Statement/Statement: "<< /Policies << /PageSize 7 >> /PageSize [396 612] /ImagingBBox null >> setpagedevice"
+*PageRegion P16K/16K: "<< /Policies << /PageSize 7 >> /PageSize [558 774] /ImagingBBox null >> setpagedevice"
+*PageRegion OficioMX/216 x 340 mm: "<< /Policies << /PageSize 7 >> /PageSize [612 964] /ImagingBBox null >> setpagedevice"
+*CloseUI: *PageRegion
+
+*% Imageable Area Definitions
+*DefaultImageableArea: A4
+*ImageableArea A4/A4: "12 10 583 832"
+*ImageableArea A5/A5: "12 10 409 585"
+*ImageableArea A6/A6: "12 10 285 411"
+*ImageableArea B5/B5 (JIS): "21 10 495 719"
+*ImageableArea ISOB5/B5 (ISO): "12 12 487 696"
+*ImageableArea OficioII/Oficio II: "12 12 600 924"
+*ImageableArea Folio/Folio (210 x 330mm): "12 12 583 923"
+*ImageableArea Statement/Statement: "12 12 384 600"
+*ImageableArea P16K/16K: "12 12 547 763"
+*ImageableArea OficioMX/216 x 340 mm: "12 12 600 952"
+*ImageableArea Letter/US-Letter: "12 08 600 776"
+*ImageableArea Legal/US-Legal: "12 08 600 1000"
+*ImageableArea Executive/US-Executive: "12 08 510 748"
+*ImageableArea EnvPersonal/Umschlag #6: "12 08 249 460"
+*ImageableArea Env9/Umschlag #9: "12 08 267 631"
+*ImageableArea Env10/Umschlag #10: "12 08 285 676"
+*ImageableArea EnvMonarch/Umschlag US-Monarch: "12 08 267 532"
+*ImageableArea EnvDL/Umschlag DL: "12 10 300 614"
+*ImageableArea EnvC5/Umschlag C5: "12 10 447 639"
+*% Physical Dimensions of Media
+*DefaultPaperDimension: A4
+*PaperDimension A4/A4: "595 842"
+*PaperDimension A5/A5: "421 595"
+*PaperDimension A6/A6: "297 421"
+*PaperDimension B5/B5 (JIS): "516 729"
+*PaperDimension ISOB5/B5 (ISO): "499 708"
+*PaperDimension OficioII/Oficio II: "612 936"
+*PaperDimension Folio/Folio (210 x 330mm): "595 935"
+*PaperDimension Statement/Statement: "396 612"
+*PaperDimension P16K/16K: "558 774"
+*PaperDimension OficioMX/216 x 340 mm: "612 964"
+*PaperDimension Letter/US-Letter: "612 792"
+*PaperDimension Legal/US-Legal: "612 1008"
+*PaperDimension Executive/US-Executive: "522 756"
+*PaperDimension EnvPersonal/Umschlag #6: "261 468"
+*PaperDimension Env9/Umschlag #9: "279 639"
+*PaperDimension Env10/Umschlag #10: "297 684"
+*PaperDimension EnvMonarch/Umschlag US-Monarch: "279 540"
+*PaperDimension EnvDL/Umschlag DL: "312 624"
+*PaperDimension EnvC5/Umschlag C5: "459 649"
+
+*% Custom Page Size Definitions
+*% Smallest = A6, Largest = LEGAL
+
+*VariablePaperSize: True
+*LeadingEdge Short: ""
+*DefaultLeadingEdge: Short
+*HWMargins: 12 12 12 12
+*MaxMediaWidth: "612"
+*MaxMediaHeight: "1008"
+*NonUIOrderDependency: 40 AnySetup *CustomPageSize
+*CustomPageSize True: "
+  pop pop pop
+  << /PageSize [ 5 -2 roll ] /ImagingBBox null
+     /DeferredMediaSelection true
+  >> setpagedevice"
+*End
+*ParamCustomPageSize Width: 1 points 278 612
+*ParamCustomPageSize Height: 2 points 420 1008
+*ParamCustomPageSize WidthOffset: 3 points 0 0
+*ParamCustomPageSize HeightOffset: 4 points 0 0
+*ParamCustomPageSize Orientation: 5 int 1 1
+
+*OpenGroup: MFFeedOptions/Papierzufuhr Handeinzug
+
+*% Manual Feed Switch Definitions
+*OpenUI *Feeding/Papierzufuhr Handeinzug: PickOne
+*OrderDependency: 40 AnySetup *Feeding
+*DefaultFeeding: Off
+*Feeding On/Ein: ""
+*Feeding Off/Aus: ""
+*CloseUI: *Feeding
+
+*CloseGroup: MFFeedOptions/Papierzufuhr Handeinzug
+
+*OpenGroup: SpeedOptions/Modus reduzierter Geschwindigkeit
+
+*% Engine Speed Definitions
+*OpenUI *EngineSpeed/Modus reduzierter Geschwindigkeit: PickOne
+*OrderDependency: 40 AnySetup *EngineSpeed
+*DefaultEngineSpeed: Off
+*EngineSpeed On/Ein: ""
+*EngineSpeed Off/Aus: ""
+*CloseUI: *EngineSpeed
+
+*CloseGroup: SpeedOptions/Modus reduzierter Geschwindigkeit
+
+*OpenGroup: CaBrightness/Helligkeit
+
+*% Adjustment Definitions
+*OpenUI *CaBrightness/Helligkeit: PickOne
+*OrderDependency: 11 AnySetup *CaBrightness
+*DefaultCaBrightness: 0
+*CaBrightness -100/-100: ""
+*CaBrightness -90/-90: ""
+*CaBrightness -80/-80: ""
+*CaBrightness -70/-70: ""
+*CaBrightness -60/-60: ""
+*CaBrightness -50/-50: ""
+*CaBrightness -40/-40: ""
+*CaBrightness -30/-30: ""
+*CaBrightness -20/-20: ""
+*CaBrightness -10/-10: ""
+*CaBrightness 0/0: ""
+*CaBrightness 10/10: ""
+*CaBrightness 20/20: ""
+*CaBrightness 30/30: ""
+*CaBrightness 40/40: ""
+*CaBrightness 50/50: ""
+*CaBrightness 60/60: ""
+*CaBrightness 70/70: ""
+*CaBrightness 80/80: ""
+*CaBrightness 90/90: ""
+*CaBrightness 100/100: ""
+*CloseUI: *CaBrightness
+
+*CloseGroup: CaBrightness/Helligkeit
+
+*OpenGroup: CaContrast/Kontrast
+
+*% Adjustment Definitions
+*OpenUI *CaContrast/Kontrast: PickOne
+*OrderDependency: 12 AnySetup *CaContrast
+*DefaultCaContrast: 0
+*CaContrast -100/-100: ""
+*CaContrast -90/-90: ""
+*CaContrast -80/-80: ""
+*CaContrast -70/-70: ""
+*CaContrast -60/-60: ""
+*CaContrast -50/-50: ""
+*CaContrast -40/-40: ""
+*CaContrast -30/-30: ""
+*CaContrast -20/-20: ""
+*CaContrast -10/-10: ""
+*CaContrast 0/0: ""
+*CaContrast 10/10: ""
+*CaContrast 20/20: ""
+*CaContrast 30/30: ""
+*CaContrast 40/40: ""
+*CaContrast 50/50: ""
+*CaContrast 60/60: ""
+*CaContrast 70/70: ""
+*CaContrast 80/80: ""
+*CaContrast 90/90: ""
+*CaContrast 100/100: ""
+*CloseUI: *CaContrast
+
+*CloseGroup: CaContrast/Kontrast
+
+*OpenGroup: MediaOptions/Medientyp
+
+*% MediaType Definitions
+*OpenUI *MediaType/Medientyp: PickOne
+*OrderDependency: 95 AnySetup *MediaType
+*DefaultMediaType: PrnDef
+*MediaType PrnDef/Automatische Medienauswahl: "<</cupsMediaType 0 >> setpagedevice"
+*MediaType Plain/Normalpapier: "<</ManualFeed false /MediaType (Plain)/cupsMediaType 1 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Labels/Etiketten: "<</ManualFeed false /MediaType (Labels)/cupsMediaType 4 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Letterhead/Briefkopf: "<</ManualFeed false /MediaType (Letterhead)/cupsMediaType 9 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Bond/Feinpapier: "<</ManualFeed false /MediaType (Bond)/cupsMediaType 5 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Color/Mehrfarbig: "<</ManualFeed false /MediaType (Color)/cupsMediaType 10 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Preprinted/Vorgedruckt: "<</ManualFeed false /MediaType (Preprinted)/cupsMediaType 3 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Prepunched/Vorgelocht: "<</ManualFeed false /MediaType (Prepunched)/cupsMediaType 11 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Recycled/Recycling-Papier: "<</ManualFeed false /MediaType (Recycled)/cupsMediaType 6 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Cardstock/Karteikarte: "<</ManualFeed false /MediaType (Card Stock)/cupsMediaType 13 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Vellum/Pergament: "<</ManualFeed false /MediaType (Vellum)/cupsMediaType 7 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Envelope/Umschlag: "<</ManualFeed false /MediaType (Envelope)/cupsMediaType 12 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Rough/Grobpapier: "<</ManualFeed false /MediaType (Rough)/cupsMediaType 8 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Thick/Dick: "<</ManualFeed false /MediaType (Thick)/cupsMediaType 16 /DeferredMediaSelection true >> setpagedevice"
+*MediaType Highqlty/Hohe Qualit<E4>t: "<</ManualFeed false /MediaType (Fine)/cupsMediaType 17 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User1/Benutzerdefinierter Typ 1: "<</ManualFeed false /MediaType (Custom Type1)/cupsMediaType 21 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User2/Benutzerdefinierter Typ 2: "<</ManualFeed false /MediaType (Custom Type2)/cupsMediaType 22 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User3/Benutzerdefinierter Typ 3: "<</ManualFeed false /MediaType (Custom Type3)/cupsMediaType 23 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User4/Benutzerdefinierter Typ 4: "<</ManualFeed false /MediaType (Custom Type4)/cupsMediaType 24 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User5/Benutzerdefinierter Typ 5: "<</ManualFeed false /MediaType (Custom Type5)/cupsMediaType 25 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User6/Benutzerdefinierter Typ 6: "<</ManualFeed false /MediaType (Custom Type6)/cupsMediaType 26 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User7/Benutzerdefinierter Typ 7: "<</ManualFeed false /MediaType (Custom Type7)/cupsMediaType 27 /DeferredMediaSelection true >> setpagedevice"
+*MediaType User8/Benutzerdefinierter Typ 8: "<</ManualFeed false /MediaType (Custom Type8)/cupsMediaType 28 /DeferredMediaSelection true >> setpagedevice"
+*CloseUI: *MediaType
+
+*CloseGroup: MediaOptions/Medientyp
+
+*RequiresPageRegion All: True
+
+*% Duplex Definitions
+*OpenUI *Duplex/Duplex: PickOne
+*OrderDependency: 50 AnySetup *Duplex
+*DefaultDuplex: None
+*Duplex None/Keine: "<</Duplex false /Tumble false>> setpagedevice"
+*Duplex DuplexTumble/Binden Kurze Seite: "<</Duplex true /Tumble true>> setpagedevice"
+*Duplex DuplexNoTumble/Binden Lange Seite: "<</Duplex true /Tumble false>> setpagedevice"
+*?Duplex: "
+  save
+  statusdict begin
+  duplexmode
+  {tumble {(DuplexTumble)}{(DuplexNoTumble)} ifelse}
+  {(None)} ifelse
+  = flush end restore"
+*End
+*CloseUI: *Duplex
+
+*% PPD Version Info 
+*OpenUI *KCVersion/PPD Version: PickOne
+*OrderDependency: 25 AnySetup *KCVersion
+*DefaultKCVersion: Default
+*KCVersion Default/1.1203 [03-23-2012]: ""
+*CloseUI: *KCVersion
+
+*% Font Information
+*DefaultFont: Courier
+*Font AvantGarde-Book: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-BookOblique: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-Demi: Standard "(001.007S)" Standard ROM
+*Font AvantGarde-DemiOblique: Standard "(001.007S)" Standard ROM
+*Font Bookman-Light: Standard "(001.004S)" Standard ROM
+*Font Bookman-LightItalic: Standard "(001.004S)" Standard ROM
+*Font Bookman-Demi: Standard "(001.004S)" Standard ROM
+*Font Bookman-DemiItalic: Standard "(001.004S)" Standard ROM
+*Font Courier: Standard "(002.004S)" Standard ROM
+*Font Courier-Oblique: Standard "(002.004S)" Standard ROM
+*Font Courier-Bold: Standard "(002.004S)" Standard ROM
+*Font Courier-BoldOblique: Standard "(002.004S)" Standard ROM
+*Font Helvetica: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Roman: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Italic: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Bold: Standard "(001.009S)" Standard ROM
+*Font NewCenturySchlbk-BoldItalic: Standard "(001.007S)" Standard ROM
+*Font Palatino-Roman: Standard "(001.005S)" Standard ROM
+*Font Palatino-Italic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Bold: Standard "(001.005S)" Standard ROM
+*Font Palatino-BoldItalic: Standard "(001.005S)" Standard ROM
+*Font Symbol: Special "(001.007S)" Special ROM
+*Font Times-Roman: Standard "(001.007S)" Standard ROM
+*Font Times-Italic: Standard "(001.007S)" Standard ROM
+*Font Times-Bold: Standard "(001.007S)" Standard ROM
+*Font Times-BoldItalic: Standard "(001.009S)" Standard ROM
+*Font ZapfChancery-MediumItalic: Standard "(001.007S)" Standard ROM
+*Font ZapfDingbats: Special "(001.004S)" Special ROM
+*Font Albertus-Medium: Standard "(001.008S)" Standard ROM
+*Font Albertus-ExtraBold: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Italic: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial: Standard "(001.008S)" Standard ROM
+*Font Arial-Italic: Standard "(001.008S)" Standard ROM
+*Font Arial-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGOmega: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Italic: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Bold: Standard "(001.008S)" Standard ROM
+*Font CGOmega-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGTimes: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Italic: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Bold: Standard "(001.008S)" Standard ROM
+*Font CGTimes-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Clarendon-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Coronet: Standard "(001.008S)" Standard ROM
+*Font CourierHP: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Italic: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Bold: Standard "(001.008S)" Standard ROM
+*Font CourierHP-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Garamond-Antiqua: Standard "(001.008S)" Standard ROM
+*Font Garamond-Halbfett: Standard "(001.008S)" Standard ROM
+*Font Garamond-Kursiv: Standard "(001.008S)" Standard ROM
+*Font Garamond-KursivHalbfett: Standard "(001.008S)" Standard ROM
+*Font LetterGothic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Italic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Bold: Standard "(001.008S)" Standard ROM
+*Font Marygold: Standard "(001.008S)" Standard ROM
+*Font SymbolMT: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Italic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Wingdings-Regular: Special "(001.008S)" Special ROM
+*?FontQuery: "
+  save
+  /str 80 string dup 0 (fonts/) putinterval def
+  {count 1 gt
+    { exch dup str 6 94 getinterval cvs
+      (/) print print (:) print
+      FontDirectory exch known
+      {(Yes)}{(No)} ifelse =
+    }{exit} ifelse
+  } bind loop (*)
+  = flush restore"
+*End
+*?FontList: "save FontDirectory { pop == } bind forall flush (*) = flush restore"
+*% Printer Messages
+*Message: "%%[ exitserver: permanent state may be changed ]%%"
+*Message: "%%[ Flushing: rest of job (to end-of-file) will be ignored ]%%"
+*Message: "\FontName\ not found, using Courier"
+
+*% Status (format: %%[ status: <one of these> ]%% )
+*Status: "warming up"/warming up
+*Status: "idle"/idle
+*Status: "busy"/busy
+*Status: "waiting"/waiting
+*Status: "printing"/printing
+*Status: "initializing"/initializing
+*Status: "printing test page"/printing test page
+*% Printer Error (format: %%[ PrinterError: <one of these> ]%% )
+*PrinterError: "paper entry misfeed"
+*PrinterError: "cover open"
+*PrinterError: "no paper tray"
+*PrinterError: "out of paper"
+*PrinterError: "toner low (halt)"
+*PrinterError: "warming up"
+*PrinterError: "other reason"
+*PrinterError: "video interface mode"
+*PrinterError: "offline"
+*PrinterError: "toner low (warning)"
+
+*% Input Sources (format: %%[ status: <stat>;source:<one of these> ]%% )
+*Source: "Serial"
+*Source: "Parallel"
+*Source: "LocalTalk"
+*Source: "Option"
+
+*%  End of PPD file for Kyocera FS-1325MFP (European German)

--- a/install.sh
+++ b/install.sh
@@ -19,11 +19,16 @@ then
     fi
 
     sudo cp Kyocera_FS-1040GDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1040GDI.ppd
+    sudo cp Kyocera_FS-1041GDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1041GDI.ppd
     sudo cp Kyocera_FS-1020MFPGDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1020MFPGDI.ppd
     sudo cp Kyocera_FS-1025MFPGDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1025MFPGDI.ppd
     sudo cp Kyocera_FS-1120MFPGDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1120MFPGDI.ppd
     sudo cp Kyocera_FS-1125MFPGDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1125MFPGDI.ppd
-    sudo cp Kyocera_FS-1060DNGDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1060DNGDI.ppd 
+    sudo cp Kyocera_FS-1220MFPGDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1220MFPGDI.ppd
+    sudo cp Kyocera_FS-1320MFPGDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1320MFPGDI.ppd
+    sudo cp Kyocera_FS-1325MFPGDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1325MFPGDI.ppd
+    sudo cp Kyocera_FS-1060DNGDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1060DNGDI.ppd
+    sudo cp Kyocera_FS-1061DNGDI.ppd /usr/share/cups/model/Kyocera/Kyocera_FS-1061DNGDI.ppd
     sudo cp bin/rastertokpsl-re /usr/lib/cups/filter/rastertokpsl
     
     if [ -f /usr/lib/cups/filter/rastertokpsl ] && [ -f /usr/share/cups/model/Kyocera/Kyocera_FS-1040GDI.ppd ] && [ -f /usr/share/cups/model/Kyocera/Kyocera_FS-1060DNGDI.ppd ] && [ -f /usr/share/cups/model/Kyocera/Kyocera_FS-1020MFPGDI.ppd ] && [ -f /usr/share/cups/model/Kyocera/Kyocera_FS-1025MFPGDI.ppd ] && [ -f /usr/share/cups/model/Kyocera/Kyocera_FS-1120MFPGDI.ppd ] && [ -f /usr/share/cups/model/Kyocera/Kyocera_FS-1125MFPGDI.ppd ]


### PR DESCRIPTION
Having tested the FS-1325MFP on arch with cups 2.4, this PR adds all printers of that product line.
Namely, FS-1041 / FS-1061DN / FS-1220MFP / FS-1320MFP / FS-1325MFP.

Thank you very much for your effort to find this fix.
Bought the FS1325MFP without checking for PCL support upfront...
This project saved me from having to return the printer and choose an inferior one, not as closely matching my use case.